### PR TITLE
MDV-12344 to Version Branch 1.1.9 Merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 package-lock.json
 build
 yarn.lock
+.mereos-local-dev
+docs
+.docs

--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@
  * LICENSE file in the root directory of this source tree.
 */
 window.mereos = window.mereos || {};
+import { addSectionSessionRecord, convertDataIntoParse, detectBrowser, detectBrowserActions, findConfigs, getSecureFeatures, getTimeInSeconds, handleBackendError, hideZendeskWidget, isMobileDevice, registerEvent, releaseAllMediaStreams, sentryExceptioMessage, updatePersistData } from './src/utils/functions';
 import { initShadowDOM, openModal, startSession } from './src/ExamsPrechecks';
 import { getRoomToken } from './src/services/twilio.services';
 import { createCandidate } from './src/services/candidate.services'; 
 import { startRecording, stopAllRecordings } from './src/StartRecording';
 import { logonSchool } from './src/services/auth.services';
 import { browserMinVersions, initialSessionData, preChecksSteps, tokenExpiredError } from './src/utils/constant';
-import { addSectionSessionRecord, convertDataIntoParse, detectBrowser, detectBrowserActions, findConfigs, getSecureFeatures, getTimeInSeconds, handleBackendError, hideZendeskWidget, isMobileDevice, registerEvent, sentryExceptioMessage, updatePersistData } from './src/utils/functions';
 import { createCandidateAssessment } from './src/services/assessment.services';
 import { v4 } from 'uuid';
 import { customCandidateAssessmentStatus } from './src/services/candidate-assessment.services';
@@ -239,26 +239,7 @@ async function stop_prechecks(callback) {
 		const chatIcons = window.mereos.shadowRoot.querySelectorAll('[id="chat-icon"]');
 		const chatContainer = window.mereos.shadowRoot.getElementById('talkjs-container');
 
-		if (window.mereos.globalStream) {
-			window.mereos.globalStream.getTracks().forEach(track => {
-				track.stop();
-				track.enabled = false;
-				track.onended = null;
-				track.onmute = null;
-				track.onunmute = null;
-			});
-			const videoElements = [
-				...document.querySelectorAll('video'),
-				...window.mereos.shadowRoot.querySelectorAll('video')
-			];
-			
-			videoElements.forEach(video => {
-				if (video.srcObject === window.mereos.globalStream) {
-					video.srcObject = null;
-				}
-			});
-			window.mereos.globalStream = null;
-		}
+		await releaseAllMediaStreams();
 		
 		if(sessionSetting !== 'session_resume'){
 			localStorage.removeItem('preChecksSteps');
@@ -459,6 +440,8 @@ async function start_session(callback) {
 
 async function stop_session(callback) {
 	try {
+		await releaseAllMediaStreams();
+
 		if (window.mereos.checkTokenInterval) {
 			clearInterval(window.mereos.checkTokenInterval);
 			window.mereos.checkTokenInterval = null;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ window.mereos = window.mereos || {};
 import { addSectionSessionRecord, convertDataIntoParse, detectBrowser, detectBrowserActions, findConfigs, getSecureFeatures, getTimeInSeconds, handleBackendError, hideZendeskWidget, isMobileDevice, registerEvent, releaseAllMediaStreams, sentryExceptioMessage, updatePersistData } from './src/utils/functions';
 import { initShadowDOM, openModal, startSession } from './src/ExamsPrechecks';
 import { getRoomToken } from './src/services/twilio.services';
-import { createCandidate } from './src/services/candidate.services'; 
+import { createCandidate } from './src/services/candidate.services';
 import { startRecording, stopAllRecordings } from './src/StartRecording';
 import { logonSchool } from './src/services/auth.services';
 import { browserMinVersions, initialSessionData, preChecksSteps, tokenExpiredError } from './src/utils/constant';
@@ -29,7 +29,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 		let logonResp;
 
 		const checkMobile = isMobileDevice();
-		if(checkMobile === 'mobile'){
+		if (checkMobile === 'mobile') {
 			return callback({
 				type: 'error',
 				message: 'mobile_devices_are_not_supported_use_desktop',
@@ -37,7 +37,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 			});
 		}
 		const info = detectBrowser();
-		let detectedBrowser = { ...info };	
+		let detectedBrowser = { ...info };
 
 		if (detectedBrowser?.browser.toLowerCase() === 'chrome' || detectedBrowser?.browser.toLowerCase() === 'edge' || detectedBrowser?.browser.toLowerCase() === 'firefox') {
 			if (detectedBrowser.version && browserMinVersions[detectedBrowser.browser] && detectedBrowser.version < browserMinVersions[detectedBrowser.browser]) {
@@ -45,7 +45,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 					type: 'error',
 					message: 'your_browser_version_is_not_compatible',
 					code: 40025,
-					details:detectedBrowser
+					details: detectedBrowser
 				});
 			}
 		}
@@ -53,7 +53,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 		try {
 			logonResp = await logonSchool(credentials);
 		} catch (error) {
-			sentryExceptioMessage(error,{
+			sentryExceptioMessage(error, {
 				type: 'error',
 				message: 'Error in logon school',
 				code: 40020,
@@ -77,8 +77,8 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 			try {
 				resp = await createCandidate(candidateData);
 			} catch (error) {
-				const message = handleBackendError(i18next.t,error?.response?.data?.message);
-				sentryExceptioMessage(error,{
+				const message = handleBackendError(i18next.t, error?.response?.data?.message);
+				sentryExceptioMessage(error, {
 					type: 'error',
 					message: error?.response?.data?.key === 'serialization_error' ? 'some_fields_are_wrong_or_data_is_incorrect' : message,
 					code: 40021,
@@ -117,9 +117,9 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 			try {
 				assessmentResp = await createCandidateAssessment(data);
 			} catch (error) {
-				const message = handleBackendError(i18next.t,error?.response?.data?.message);
+				const message = handleBackendError(i18next.t, error?.response?.data?.message);
 				localStorage.removeItem('mereosToken');
-				sentryExceptioMessage(error,{
+				sentryExceptioMessage(error, {
 					type: 'error',
 					message: error?.response?.data?.key === 'serialization_error' ? 'some_fields_are_wrong_or_data_is_incorrect' : message,
 					code: 40021,
@@ -145,9 +145,9 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 				try {
 					candidateAssessmentResp = await customCandidateAssessmentStatus(candidateAssessmentData);
 				} catch (error) {
-					const message = handleBackendError(i18next.t,error?.response?.data?.message);
+					const message = handleBackendError(i18next.t, error?.response?.data?.message);
 					localStorage.removeItem('mereosToken');
-					sentryExceptioMessage(error,{
+					sentryExceptioMessage(error, {
 						type: 'error',
 						message: error?.response?.data?.key === 'serialization_error' ? 'some_fields_are_wrong_or_data_is_incorrect' : message,
 						code: 40021,
@@ -161,7 +161,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 					});
 				}
 
-				Sentry.setUser({ id: resp?.data?.id, email: resp?.data?.email,name: resp?.data?.name });
+				Sentry.setUser({ id: resp?.data?.id, email: resp?.data?.email, name: resp?.data?.name });
 
 				updatePersistData('session', {
 					candidate_assessment: candidateAssessmentResp?.data?.id,
@@ -180,7 +180,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 			});
 		}
 	} catch (error) {
-		sentryExceptioMessage(error,{
+		sentryExceptioMessage(error, {
 			type: 'error',
 			message: 'Error in init function',
 			code: 40022,
@@ -195,7 +195,7 @@ async function init(credentials, candidateData, profileId, assessmentData, schoo
 	}
 }
 
-async function start_prechecks(callback,setting) {
+async function start_prechecks(callback, setting) {
 	try {
 		window.mereos.globalCallback = callback;
 		const tokenData = localStorage.getItem('mereosToken');
@@ -203,29 +203,29 @@ async function start_prechecks(callback,setting) {
 			localStorage.removeItem('mereosToken');
 			return callback(tokenExpiredError);
 		}
-		
-		if(!setting){
+
+		if (!setting) {
 			localStorage.removeItem('navHistory');
 		}
 
 		localStorage.setItem('precheckSetting', setting);
 		initShadowDOM();
-		window.mereos.precheckCompleted=false;
+		window.mereos.precheckCompleted = false;
 		const savedData = await startSession();
-		if(savedData === 'data_saved'){
+		if (savedData === 'data_saved') {
 			openModal(callback);
 		}
 	} catch (error) {
-		sentryExceptioMessage(error,{
+		sentryExceptioMessage(error, {
 			type: 'error',
 			message: 'Error in prechecks setup',
-			code:40000,
+			code: 40000,
 			details: error,
 		});
 		callback({
 			type: 'error',
 			message: 'error_in_prechecks_setup',
-			code:40000,
+			code: 40000,
 			details: error,
 		});
 	}
@@ -240,10 +240,10 @@ async function stop_prechecks(callback) {
 		const chatContainer = window.mereos.shadowRoot.getElementById('talkjs-container');
 
 		await releaseAllMediaStreams();
-		
-		if(sessionSetting !== 'session_resume'){
+
+		if (sessionSetting !== 'session_resume') {
 			localStorage.removeItem('preChecksSteps');
-			localStorage.setItem('navHistory',JSON.stringify([]));
+			localStorage.setItem('navHistory', JSON.stringify([]));
 		}
 		if (chatIcons.length > 0) {
 			chatIcons.forEach(icon => {
@@ -270,7 +270,7 @@ async function stop_prechecks(callback) {
 			code: 50002
 		});
 	} catch (error) {
-		sentryExceptioMessage(error,{
+		sentryExceptioMessage(error, {
 			type: 'error',
 			message: 'Error in stop prechecks',
 			details: error,
@@ -285,15 +285,38 @@ async function stop_prechecks(callback) {
 	}
 }
 
+/**
+ * Starts the proctored exam session and notifies the LMS via callback.
+ *
+ * Flow:
+ * 1. Store LMS callback → detectBrowserActions (navigation violations on active session)
+ * 2. Validate token and prechecks
+ * 3. If Twilio room already connected → success callback only
+ * 4. Reset stale recordingStart flag from a prior failed attempt
+ * 5. Preserve quizStartTime; on session_resume reuse stored Twilio tokens
+ * 6. await startRecording() — final success/error callback fires inside that function
+ */
 async function start_session(callback) {
+	/*
+	 * LMS callback helper: always notify the integrator even if startRecordingCallBack
+	 * was cleared elsewhere. Falls back to the callback argument passed into start_session.
+	 */
+	const invokeCallback = (payload) => {
+		const cb = window.mereos.startRecordingCallBack || callback;
+		if (typeof cb === 'function') {
+			cb(payload);
+		}
+	};
+
 	try {
+		// Store callback for async paths inside startRecording (Twilio, media, etc.).
 		window.mereos.startRecordingCallBack = callback;
 		await detectBrowserActions();
 		const secureFeatures = getSecureFeatures();
 		const tokenData = localStorage.getItem('mereosToken');
 		if (!tokenData || Date.now() > JSON.parse(tokenData).expiresAt) {
 			localStorage.removeItem('mereosToken');
-			return callback(tokenExpiredError);
+			return invokeCallback(tokenExpiredError);
 		}
 		const hasRecordScreen = findConfigs(['record_screen'], secureFeatures?.entities).length > 0;
 		const hasMobileProctoring = findConfigs(['mobile_proctoring'], secureFeatures?.entities).length > 0;
@@ -302,14 +325,14 @@ async function start_session(callback) {
 		const mobileStream = !window.mereos?.mobileStream;
 
 		if (
-			(hasRecordScreen && screenShareStream && notCompleted) || 
+			(hasRecordScreen && screenShareStream && notCompleted) ||
 			(hasMobileProctoring && notCompleted && !mobileStream)
 		) {
-			updatePersistData('preChecksSteps', { 
+			updatePersistData('preChecksSteps', {
 				mobileConnection: false,
 				screenSharing: false
 			});
-			window.mereos.startRecordingCallBack({ 
+			invokeCallback({
 				type: 'error',
 				message: 'please_complete_your_prechecks',
 				code: 40019
@@ -317,123 +340,191 @@ async function start_session(callback) {
 			return;
 		}
 
-		if(!window.mereos.roomInstance && !window.mereos.recordingStart){
-			window.mereos.recordingStart = true;
-			const dateTime = new Date();
-			const currentTimeInSeconds = Math.abs(getTimeInSeconds({ isUTC: true, inputDate: dateTime }));
-            
-			const previousSessionData = convertDataIntoParse('session') || {};
-			
-			let quizStartTime = previousSessionData.quizStartTime;
-			if (!quizStartTime || quizStartTime <= 0) {
-				quizStartTime = currentTimeInSeconds;
-			}
-	
-			updatePersistData('session', {
-				quizStartTime: quizStartTime,
-				lastUpdated: currentTimeInSeconds
+		// Twilio room is already live — report success without creating a duplicate room.
+		if (window.mereos.roomInstance) {
+			invokeCallback({
+				type: 'success',
+				message: 'recording_started_successfully',
+				code: 50000,
 			});
+			return;
+		}
 
-			if (secureFeatures?.entities?.length > 0) {
-				const mobileRoomSessionId = v4();
-				const newRoomSessionId = v4();
-				
-				if (findConfigs(['mobile_proctoring'], secureFeatures?.entities).length) {
-					try {
-						const resp = await getRoomToken({ room_name: mobileRoomSessionId, identity: mobileRoomSessionId });
-						const mobileTwilioToken = resp?.data?.token;
-	
-						updatePersistData('session', {
-							mobileRoomId: resp.data.room_sid,
-							mobileRoomSessionId: mobileRoomSessionId,
-							mobileTwilioToken:mobileTwilioToken
-						});
-	
-						if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
-							window.mereos.socket.send(
-								JSON.stringify({
-									event: 'twilioToken',
-									message:mobileTwilioToken,
-								})
-							);
-						}
-					} catch (err) {
-						sentryExceptioMessage(err,{
-							type: 'error',
-							message: 'Error in mobile proctoring setup',
-							details: err,
-							code:40002
-						});
-						if(window.mereos.startRecordingCallBack){
-							window.mereos.startRecordingCallBack({
-								type: 'error',
-								message: 'error_in_mobile_proctoring_setup',
-								details: err,
-								code:40002
-							});
-						}
-						return;
+		/*
+		 * recordingStart can remain true after a failed/interrupted attempt while roomInstance
+		 * is null. Reset so the flow below can run again instead of exiting silently.
+		 */
+		if (window.mereos.recordingStart) {
+			window.mereos.recordingStart = false;
+		}
+
+		window.mereos.recordingStart = true;
+		const dateTime = new Date();
+		const currentTimeInSeconds = Math.abs(getTimeInSeconds({ isUTC: true, inputDate: dateTime }));
+
+		const previousSessionData = convertDataIntoParse('session') || {};
+		// session_resume is set by start_prechecks(callback, 'session_resume') after reload/interruption.
+		const sessionSetting = localStorage.getItem('precheckSetting');
+
+		// Preserve quiz start time across resume; only set on first start.
+		let quizStartTime = previousSessionData.quizStartTime;
+		if (!quizStartTime || quizStartTime <= 0) {
+			quizStartTime = currentTimeInSeconds;
+		}
+
+		updatePersistData('session', {
+			quizStartTime: quizStartTime,
+			lastUpdated: currentTimeInSeconds
+		});
+
+		if (secureFeatures?.entities?.length > 0) {
+			const mobileRoomSessionId = v4();
+			const newRoomSessionId = v4();
+			/*
+			 * On session_resume only: reuse Twilio tokens from localStorage instead of new rooms.
+			 * Fresh starts always fetch new tokens below.
+			 */
+			const canReuseMobileToken = sessionSetting === 'session_resume' && previousSessionData.mobileTwilioToken;
+			const canReuseTwilioToken = sessionSetting === 'session_resume' && previousSessionData.twilioToken;
+
+			// Mobile proctoring room token
+			if (findConfigs(['mobile_proctoring'], secureFeatures?.entities).length && !canReuseMobileToken) {
+				try {
+					const resp = await getRoomToken({ room_name: mobileRoomSessionId, identity: mobileRoomSessionId });
+					const mobileTwilioToken = resp?.data?.token;
+
+					updatePersistData('session', {
+						mobileRoomId: resp.data.room_sid,
+						mobileRoomSessionId: mobileRoomSessionId,
+						mobileTwilioToken: mobileTwilioToken
+					});
+
+					if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
+						window.mereos.socket.send(
+							JSON.stringify({
+								event: 'twilioToken',
+								message: mobileTwilioToken,
+							})
+						);
 					}
+				} catch (err) {
+					window.mereos.recordingStart = false;
+					sentryExceptioMessage(err, {
+						type: 'error',
+						message: 'Error in mobile proctoring setup',
+						details: err,
+						code: 40002
+					});
+					invokeCallback({
+						type: 'error',
+						message: 'error_in_mobile_proctoring_setup',
+						details: err,
+						code: 40002
+					});
+					return;
 				}
-	
-				const roomCreation = ['record_screen', 'record_audio', 'record_video', 'mobile_proctoring'];
-				if (secureFeatures?.entities.filter((entity) => roomCreation.includes(entity.key)).length > 0) {
-					try {
-						const resp = await getRoomToken({ room_name: newRoomSessionId, identity: newRoomSessionId });
-						const twilioToken = resp?.data?.token;
-	
-						if (twilioToken) {
-							updatePersistData('session', {
-								twilioToken: twilioToken,
-								sessionId: newRoomSessionId,
-							});
-						}
-					} catch (err) {
-						sentryExceptioMessage(err,{
-							type: 'error',
-							message: 'Error in web room creation',
-							details: err,
-							code:40003
+				// session_resume: re-send stored mobile token to the signaling socket.
+			} else if (canReuseMobileToken && window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
+				window.mereos.socket.send(
+					JSON.stringify({
+						event: 'twilioToken',
+						message: previousSessionData.mobileTwilioToken,
+					})
+				);
+			}
+
+			const roomCreation = ['record_screen', 'record_audio', 'record_video', 'mobile_proctoring'];
+			const needsWebRoom = secureFeatures?.entities.filter((entity) => roomCreation.includes(entity.key)).length > 0;
+			// Web recording room token (skip fetch when resuming with stored token)
+			if (needsWebRoom && !canReuseTwilioToken) {
+				try {
+					const resp = await getRoomToken({ room_name: newRoomSessionId, identity: newRoomSessionId });
+					const twilioToken = resp?.data?.token;
+
+					if (twilioToken) {
+						updatePersistData('session', {
+							twilioToken: twilioToken,
+							sessionId: newRoomSessionId,
 						});
-						window.mereos.startRecordingCallBack({
+						// No token in API response and none stored — cannot connect.
+					} else if (!previousSessionData.twilioToken) {
+						window.mereos.recordingStart = false;
+						invokeCallback({
 							type: 'error',
 							message: 'error_in_web_room_creation',
-							details: err,
-							code:40003
+							code: 40003,
+							details: 'Twilio token missing from room creation response',
 						});
 						return;
 					}
+				} catch (err) {
+					window.mereos.recordingStart = false;
+					sentryExceptioMessage(err, {
+						type: 'error',
+						message: 'Error in web room creation',
+						details: err,
+						code: 40003
+					});
+					invokeCallback({
+						type: 'error',
+						message: 'error_in_web_room_creation',
+						details: err,
+						code: 40003
+					});
+					return;
 				}
-	
-				startRecording();
-			} else {
-				window.mereos.startRecordingCallBack({ 
-					type:'success',
-					message: 'recording_started_successfully',
-					code:50000
-				});
 			}
+
+			// Final guard before Twilio connect inside startRecording.
+			if (needsWebRoom) {
+				const sessionWithToken = convertDataIntoParse('session');
+				if (!sessionWithToken?.twilioToken) {
+					window.mereos.recordingStart = false;
+					invokeCallback({
+						type: 'error',
+						message: 'error_in_web_room_creation',
+						code: 40003,
+						details: 'Twilio token is missing',
+					});
+					return;
+				}
+			}
+
+			/*
+			 * Await so errors propagate here and invokeCallback runs in the catch below.
+			 * Success/error callbacks for recording also fire inside startRecording.
+			 */
+			await startRecording();
+		} else {
+			// No proctoring features — session starts immediately with success callback.
+			invokeCallback({
+				type: 'success',
+				message: 'recording_started_successfully',
+				code: 50000
+			});
 		}
 	} catch (err) {
-		console.log('err_________',err);
+		// Allow retry after unexpected failure in this function.
+		window.mereos.recordingStart = false;
+		console.log('err_________', err);
 		if (typeof registerEvent !== 'undefined' && typeof registerEvent === 'function') {
-			registerEvent({ 
-				eventType: 'success', 
-				notify: false, 
+			registerEvent({
+				eventType: 'success',
+				notify: false,
 				eventName: 'error_starting_session',
 			});
 		}
-		sentryExceptioMessage(err,{
+		sentryExceptioMessage(err, {
 			type: 'error',
 			message: 'Error in starting the session',
 			details: err,
-			code:40004
+			code: 40004
 		});
-		callback({
+		invokeCallback({
 			type: 'error',
 			message: 'error_in_starting_the_session',
 			details: err,
-			code:40004
+			code: 40004
 		});
 	}
 }
@@ -446,7 +537,7 @@ async function stop_session(callback) {
 			clearInterval(window.mereos.checkTokenInterval);
 			window.mereos.checkTokenInterval = null;
 		}
-		window.mereos.stopRecordingCallBack=callback;
+		window.mereos.stopRecordingCallBack = callback;
 		const tokenData = localStorage.getItem('mereosToken');
 		if (!tokenData || Date.now() > JSON.parse(tokenData).expiresAt) {
 			localStorage.removeItem('mereosToken');
@@ -457,7 +548,7 @@ async function stop_session(callback) {
 		if (stopSessionResp === 'stop_recording') {
 			const candidateInviteAssessmentSection = convertDataIntoParse('candidateAssessment');
 			const session = convertDataIntoParse('session');
-							
+
 			const resp = await addSectionSessionRecord(session, candidateInviteAssessmentSection);
 
 			if (resp) {
@@ -468,10 +559,10 @@ async function stop_session(callback) {
 				];
 				keysToRemove.forEach((key) => localStorage.removeItem(key));
 
-				callback({ 
-					type: 'success', 
-					message: 'session_finished_successfully', 
-					code: 50003 
+				callback({
+					type: 'success',
+					message: 'session_finished_successfully',
+					code: 50003
 				});
 			} else {
 				throw new Error('Session can\'t be added');
@@ -480,18 +571,18 @@ async function stop_session(callback) {
 			throw 'session can\'t add';
 		}
 	} catch (err) {
-		sentryExceptioMessage(err,{
-			type: 'error', 
-			message: 'Error in stopping the session' , 
-			code:40016 
+		sentryExceptioMessage(err, {
+			type: 'error',
+			message: 'Error in stopping the session',
+			code: 40016
 		});
 		callback({
-			type: 'error', 
-			message: 'error_in_stopping_the_session' , 
-			code:40016 
+			type: 'error',
+			message: 'error_in_stopping_the_session',
+			code: 40016
 		});
 	}
 }
 
 // window.mereos.mereos = {init, start_prechecks, start_session, stop_session};
-export {init, start_prechecks,stop_prechecks, start_session, stop_session };
+export { init, start_prechecks, stop_prechecks, start_session, stop_session };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"@babel/plugin-transform-optional-chaining": "^7.28.6",
 		"@babel/preset-env": "^7.29.0",
 		"@sentry/browser": "^10.38.0",
-		"@sentry/replay": "^7.116.0",
 		"@tensorflow-models/coco-ssd": "2.2.3",
 		"@tensorflow/tfjs": "4.21.0",
 		"@twilio/rtc-diagnostics": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,62 +1,64 @@
 {
-  "name": "mereos",
-  "version": "1.1.9",
-  "description": "This is an ai-empowered proctoring solution for online assessments.",
-  "main": "index.js",
-  "scripts": {
-    "test": "jest --silent=false --verbose",
-    "lint": "eslint ./**/*.js",
-    "lint:fix": "eslint --fix ./**/*.js"
-  },
-  "browserslist": [
-    ">0.2%",
-    "not dead",
-    "not op_mini all"
-  ],
-  "keywords": [
-    "mereos",
-    "proctoring",
-    "ai",
-    "online",
-    "assessment"
-  ],
-  "author": "DT Education",
-  "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Drone9/mereos.git"
-  },
-  "dependencies": {
-    "@babel/plugin-transform-optional-chaining": "^7.28.6",
-    "@babel/preset-env": "^7.29.0",
-    "@sentry/browser": "^10.38.0",
-    "@sentry/replay": "^7.116.0",
-    "@tensorflow-models/coco-ssd": "2.2.3",
-    "@tensorflow/tfjs": "4.21.0",
-    "@twilio/rtc-diagnostics": "^1.0.1",
-    "axios": "^0.26.1",
-    "del": "^8.0.0",
-    "detectincognitojs": "^1.6.2",
-    "eslint": "8.56.0",
-    "i18next": "^23.11.5",
-    "interactjs": "^1.10.27",
-    "notyf": "^3.10.0",
-    "peerjs": "^1.5.5",
-    "qrcode": "^1.5.4",
-    "talkjs": "^0.31.0",
-    "twilio-video": "2.28.0",
-    "uuid": "^10.0.0"
-  },
-  "devDependencies": {
-    "@babel/eslint-parser": "^7.28.6",
-    "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.4.8",
-    "esbuild-jest": "^0.4.0",
-    "eslint-plugin-import": "^2.25.2",
-    "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
-    "eslint-plugin-promise": "^6.0.0",
-    "identity-obj-proxy": "^3.0.0",
-    "jest": "^30.2.0",
-    "jest-environment-jsdom": "^29.7.0"
-  }
+	"name": "mereos",
+	"version": "1.1.9",
+	"description": "This is an ai-empowered proctoring solution for online assessments.",
+	"main": "index.js",
+	"scripts": {
+		"dev": "node scripts/dev.mjs",
+		"test": "jest --silent=false --verbose",
+		"lint": "eslint ./**/*.js",
+		"lint:fix": "eslint --fix ./**/*.js"
+	},
+	"browserslist": [
+		">0.2%",
+		"not dead",
+		"not op_mini all"
+	],
+	"keywords": [
+		"mereos",
+		"proctoring",
+		"ai",
+		"online",
+		"assessment"
+	],
+	"author": "DT Education",
+	"license": "MIT",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Drone9/mereos.git"
+	},
+	"dependencies": {
+		"@babel/plugin-transform-optional-chaining": "^7.28.6",
+		"@babel/preset-env": "^7.29.0",
+		"@sentry/browser": "^10.38.0",
+		"@sentry/replay": "^7.116.0",
+		"@tensorflow-models/coco-ssd": "2.2.3",
+		"@tensorflow/tfjs": "4.21.0",
+		"@twilio/rtc-diagnostics": "^1.0.1",
+		"axios": "^0.26.1",
+		"del": "^8.0.0",
+		"detectincognitojs": "^1.6.2",
+		"eslint": "8.56.0",
+		"i18next": "^23.11.5",
+		"interactjs": "^1.10.27",
+		"notyf": "^3.10.0",
+		"peerjs": "^1.5.5",
+		"qrcode": "^1.5.4",
+		"talkjs": "^0.31.0",
+		"twilio-video": "2.28.0",
+		"uuid": "^10.0.0"
+	},
+	"devDependencies": {
+		"@babel/eslint-parser": "^7.28.6",
+		"@testing-library/dom": "^10.4.0",
+		"@testing-library/jest-dom": "^6.4.8",
+		"esbuild-jest": "^0.4.0",
+		"eslint-plugin-import": "^2.25.2",
+		"eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
+		"eslint-plugin-promise": "^6.0.0",
+		"identity-obj-proxy": "^3.0.0",
+		"jest": "^30.2.0",
+		"jest-environment-jsdom": "^29.7.0",
+		"vite": "^6.3.5"
+	}
 }

--- a/scripts/dev-ui/browser-compat-plugin.mjs
+++ b/scripts/dev-ui/browser-compat-plugin.mjs
@@ -1,0 +1,143 @@
+import path from 'path';
+
+function patchFunctionsJs(content) {
+	if (content.includes('cyTranslation')) {
+		return content;
+	}
+
+	const localeImports = `
+import cyTranslation from '../assets/locales/cy/translation.json';
+import enTranslation from '../assets/locales/en/translation.json';
+import frTranslation from '../assets/locales/fr/translation.json';
+import itTranslation from '../assets/locales/it/translation.json';
+import ptTranslation from '../assets/locales/pt/translation.json';
+import nlTranslation from '../assets/locales/nl/translation.json';
+import esTranslation from '../assets/locales/es/translation.json';
+import deTranslation from '../assets/locales/de/translation.json';`;
+
+	content = content.replace(
+		"import * as Sentry from '@sentry/browser';",
+		`import * as Sentry from '@sentry/browser';${localeImports}`,
+	);
+
+	const localeMap = [
+		["require('../assets/locales/cy/translation.json')", 'cyTranslation'],
+		["require('../assets/locales/en/translation.json')", 'enTranslation'],
+		["require('../assets/locales/fr/translation.json')", 'frTranslation'],
+		["require('../assets/locales/it/translation.json')", 'itTranslation'],
+		["require('../assets/locales/pt/translation.json')", 'ptTranslation'],
+		["require('../assets/locales/nl/translation.json')", 'nlTranslation'],
+		["require('../assets/locales/es/translation.json')", 'esTranslation'],
+		["require('../assets/locales/de/translation.json')", 'deTranslation'],
+	];
+
+	for (const [from, to] of localeMap) {
+		content = content.split(from).join(to);
+	}
+
+	return content;
+}
+
+function patchSocketJs(content) {
+	if (content.includes("import { SOCKET_URL }")) {
+		return content;
+	}
+
+	const normalized = content.replace(/\r\n/g, '\n');
+	const patched = normalized.replace(
+		`const { SOCKET_URL } = require('./constant');
+const { v4 } = require('uuid');`,
+		`import { SOCKET_URL } from './constant';
+import { v4 } from 'uuid';`,
+	);
+
+	return patched === normalized
+		? content.replace(
+			"const { SOCKET_URL } = require('./constant');",
+			"import { SOCKET_URL } from './constant';",
+		).replace(
+			"const { v4 } = require('uuid');",
+			"import { v4 } from 'uuid';",
+		)
+		: patched;
+}
+
+function patchI18nJs(content) {
+	if (content.includes('itTranslation')) {
+		return content;
+	}
+
+	return content
+		.replace(
+			"import { logger } from './functions';",
+			`import { logger } from './functions';
+import itTranslation from './locales/it/translations.json';`,
+		)
+		.replace(
+			"translation: require('./locales/it/translations.json')",
+			'translation: itTranslation',
+		);
+}
+
+function normalizeId(id) {
+	return id.split('?')[0].replace(/\\/g, '/');
+}
+
+function patchFile(file, content) {
+	if (file.endsWith('/src/utils/functions.js')) {
+		return patchFunctionsJs(content);
+	}
+	if (file.endsWith('/src/utils/socket.js')) {
+		return patchSocketJs(content);
+	}
+	if (file.endsWith('/src/utils/i18n.js')) {
+		return patchI18nJs(content);
+	}
+	return null;
+}
+
+function isLibraryFile(file, projectRoot) {
+	const normalized = file.replace(/\\/g, '/');
+	const root = projectRoot.replace(/\\/g, '/');
+	return normalized.startsWith(`${root}/src/`) || normalized === `${root}/index.js`;
+}
+
+export function browserCompatPlugin(projectRoot) {
+	const root = projectRoot.replace(/\\/g, '/');
+
+	return {
+		name: 'mereos-browser-compat',
+		enforce: 'pre',
+		transform(code, id) {
+			const file = normalizeId(id);
+			if (!file.startsWith(root)) {
+				return null;
+			}
+			const patched = patchFile(file, code);
+			return patched ? { code: patched, map: null } : null;
+		},
+		configureServer(server) {
+			server.watcher.add(path.join(projectRoot, 'index.js'));
+			server.watcher.add(path.join(projectRoot, 'src'));
+		},
+		handleHotUpdate({ file, server }) {
+			if (!isLibraryFile(file, projectRoot)) {
+				return;
+			}
+
+			const modules = new Set();
+			for (const mod of server.moduleGraph.getModulesByFile(file) ?? []) {
+				modules.add(mod);
+				mod.importers.forEach((importer) => modules.add(importer));
+			}
+
+			const mereosEntry = path.join(projectRoot, 'index.js');
+			for (const mod of server.moduleGraph.getModulesByFile(mereosEntry) ?? []) {
+				modules.add(mod);
+				mod.importers.forEach((importer) => modules.add(importer));
+			}
+
+			return [...modules];
+		},
+	};
+}

--- a/scripts/dev-ui/defaults.js
+++ b/scripts/dev-ui/defaults.js
@@ -1,0 +1,22 @@
+export const defaultInitPayload = {
+	host: {
+		client_id: '3425fefd731c4ab3856a8a265698ad49',
+		client_secret: 'HZuIPfKLQYlBVYW_4iZAc6WJf862Mu6F_hTzeC5k8wA',
+	},
+	profileID: 216,
+	candidateData: {
+		name: 'John Doe',
+		email: 'john.doe@example.com',
+		external_id: 3,
+		external_name: 2,
+		branch: 4,
+	},
+	assessmentData: {
+		name: 'cloud new assessment',
+		description: 'Assessment description',
+		external_id: 896,
+		course_id: 1,
+		others: { test: 'value' },
+		branch: 4,
+	},
+};

--- a/scripts/dev-ui/index.html
+++ b/scripts/dev-ui/index.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Mereos Dev</title>
+	<style>
+		* { box-sizing: border-box; }
+		body {
+			font-family: system-ui, -apple-system, sans-serif;
+			margin: 0;
+			padding: 24px;
+			background: #f4f6f8;
+			color: #1a1a1a;
+		}
+		h1 { margin: 0 0 16px; font-size: 1.5rem; }
+		.nav {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px;
+			margin-bottom: 20px;
+		}
+		.nav button {
+			padding: 8px 16px;
+			border: 1px solid #d0d7de;
+			border-radius: 6px;
+			background: #fff;
+			color: #1a1a1a;
+			font: inherit;
+			cursor: pointer;
+		}
+		.nav button:hover { background: #f6f8fa; }
+		.nav button.primary {
+			background: #e85d04;
+			border-color: #e85d04;
+			color: #fff;
+		}
+		.nav button.primary:hover { background: #d35400; }
+		.nav button:disabled {
+			opacity: 0.45;
+			cursor: not-allowed;
+		}
+		.panel {
+			background: #fff;
+			border-radius: 8px;
+			padding: 20px;
+			margin-bottom: 16px;
+			box-shadow: 0 1px 3px rgba(0,0,0,.08);
+		}
+		.settings-grid {
+			display: grid;
+			grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+			gap: 16px;
+			margin-bottom: 16px;
+		}
+		.field label {
+			display: block;
+			font-size: 13px;
+			font-weight: 600;
+			margin-bottom: 6px;
+		}
+		.field input[type="color"] {
+			width: 100%;
+			height: 36px;
+			padding: 2px;
+			border: 1px solid #d0d7de;
+			border-radius: 6px;
+			cursor: pointer;
+		}
+		.field select {
+			width: 100%;
+			padding: 8px 10px;
+			border: 1px solid #d0d7de;
+			border-radius: 6px;
+			font: inherit;
+			background: #fff;
+		}
+		.mode-options {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+			margin-top: 4px;
+		}
+		.mode-options label {
+			font-weight: 400;
+			display: flex;
+			align-items: center;
+			gap: 8px;
+			cursor: pointer;
+		}
+		#initJson {
+			width: 100%;
+			min-height: 320px;
+			padding: 12px;
+			border: 1px solid #d0d7de;
+			border-radius: 6px;
+			font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+			font-size: 13px;
+			line-height: 1.5;
+			resize: vertical;
+		}
+		#log {
+			background: #0d1117;
+			color: #c9d1d9;
+			padding: 12px;
+			border-radius: 6px;
+			min-height: 120px;
+			max-height: 280px;
+			overflow: auto;
+			font-family: ui-monospace, monospace;
+			font-size: 12px;
+			white-space: pre-wrap;
+		}
+		.json-label {
+			display: block;
+			font-size: 13px;
+			font-weight: 600;
+			margin-bottom: 8px;
+		}
+		.steps {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 8px;
+			margin-bottom: 16px;
+		}
+		.step {
+			padding: 6px 12px;
+			border-radius: 999px;
+			font-size: 12px;
+			font-weight: 600;
+			background: #eaeef2;
+			color: #57606a;
+		}
+		.step.active { background: #ddf4ff; color: #0969da; }
+		.step.done { background: #dafbe1; color: #1a7f37; }
+		#flowStatus {
+			margin: 0 0 12px;
+			font-size: 14px;
+			color: #57606a;
+		}
+		.requirements {
+			margin: 0;
+			padding-left: 20px;
+			font-size: 13px;
+			line-height: 1.6;
+			color: #424a53;
+		}
+		.requirements li { margin-bottom: 4px; }
+		.hint-box {
+			background: #fff8c5;
+			border: 1px solid #d4a72c;
+			border-radius: 6px;
+			padding: 10px 12px;
+			font-size: 13px;
+			margin-bottom: 16px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Init JSON Input</h1>
+
+	<p id="flowStatus">Step 1: Click Login to authenticate and open prechecks.</p>
+
+	<div class="steps" id="stepIndicator">
+		<span class="step active" data-step="login">1. Login (init)</span>
+		<span class="step" data-step="prechecks">2. Prechecks</span>
+		<span class="step" data-step="session">3. Start session</span>
+		<span class="step" data-step="stop">4. Stop session</span>
+	</div>
+
+	<div class="hint-box">
+		<strong>How the library works:</strong> Login only calls the API — it does not show UI.
+		After a successful login, prechecks open automatically in a modal overlay.
+		Complete every step in that modal, then use <strong>Start Session</strong> to begin recording.
+	</div>
+
+	<nav class="nav">
+		<button id="btnInit" class="primary" type="button">Login</button>
+		<button id="btnPrechecks" type="button" disabled>Start Prechecks</button>
+		<button id="btnStopPrechecks" type="button" disabled>Stop Prechecks</button>
+		<button id="btnSession" type="button" disabled>Start Session</button>
+		<button id="btnStopSession" type="button" disabled>Stop Session</button>
+	</nav>
+
+	<div class="panel">
+		<div class="settings-grid">
+			<div class="field">
+				<label for="themeColor">Theme Color</label>
+				<input id="themeColor" type="color" value="#1a7f37" />
+			</div>
+
+			<div class="field">
+				<label>Theme Mode</label>
+				<div class="mode-options">
+					<label><input id="lightMode" type="checkbox" /> Light Mode</label>
+					<label><input id="darkMode" type="checkbox" checked /> Dark Mode</label>
+				</div>
+			</div>
+
+			<div class="field">
+				<label for="language">Language</label>
+				<select id="language">
+					<option value="en" selected>English</option>
+					<option value="es">Spanish</option>
+					<option value="de">German</option>
+					<option value="fr">French</option>
+					<option value="pt">Portuguese (Brazil)</option>
+					<option value="it">Italian</option>
+					<option value="nl">Dutch</option>
+					<option value="cy">Welsh</option>
+				</select>
+			</div>
+
+			<div class="field">
+				<label for="fontStyle">Font Style</label>
+				<select id="fontStyle">
+					<option value="normal">Normal</option>
+					<option value="italic" selected>Italic</option>
+				</select>
+			</div>
+		</div>
+
+		<label class="json-label" for="initJson">Init payload (editable JSON)</label>
+		<textarea id="initJson" spellcheck="false"></textarea>
+	</div>
+
+	<div class="panel">
+		<label class="json-label">Requirements for the full flow</label>
+		<ul class="requirements">
+			<li><strong>Valid API credentials</strong> — active Mereos <code>client_id</code> / <code>client_secret</code></li>
+			<li><strong>Valid profile ID</strong> — proctoring profile configured in the Mereos admin panel</li>
+			<li><strong>Desktop browser</strong> — Chrome, Edge, or Firefox (mobile is blocked)</li>
+			<li><strong>Camera &amp; microphone</strong> — browser permission when prechecks ask for them</li>
+			<li><strong>Screen sharing</strong> — required if your profile enables <code>record_screen</code></li>
+			<li><strong>Mereos Mobile app</strong> — required if your profile enables <code>mobile_proctoring</code></li>
+			<li><strong>Internet access</strong> — API (<code>corder-api.mereos-datasafe.com</code>) and Twilio/WebSocket services</li>
+			<li><strong>localhost or HTTPS</strong> — needed for camera/mic APIs (Vite dev server on localhost is fine)</li>
+		</ul>
+	</div>
+
+	<div class="panel">
+		<label class="json-label">Console log</label>
+		<div id="log"></div>
+	</div>
+
+	<script type="module" src="/main.js"></script>
+</body>
+</html>

--- a/scripts/dev-ui/main.js
+++ b/scripts/dev-ui/main.js
@@ -1,0 +1,297 @@
+import { defaultInitPayload } from './defaults.js';
+
+const logEl = document.getElementById('log');
+const flowStatusEl = document.getElementById('flowStatus');
+const initJsonEl = document.getElementById('initJson');
+const lightModeEl = document.getElementById('lightMode');
+const darkModeEl = document.getElementById('darkMode');
+
+const btnInit = document.getElementById('btnInit');
+const btnPrechecks = document.getElementById('btnPrechecks');
+const btnStopPrechecks = document.getElementById('btnStopPrechecks');
+const btnSession = document.getElementById('btnSession');
+const btnStopSession = document.getElementById('btnStopSession');
+
+const FLOW = {
+	login: 'login',
+	prechecks: 'prechecks',
+	session: 'session',
+	stop: 'stop',
+};
+
+let currentStep = FLOW.login;
+let initSucceeded = false;
+let prechecksCompleted = false;
+let sessionStarted = false;
+
+if (!initJsonEl.value.trim()) {
+	initJsonEl.value = JSON.stringify(defaultInitPayload, null, 2);
+}
+
+lightModeEl.addEventListener('change', () => {
+	if (lightModeEl.checked) darkModeEl.checked = false;
+});
+
+darkModeEl.addEventListener('change', () => {
+	if (darkModeEl.checked) lightModeEl.checked = false;
+});
+
+let mereosApi;
+
+async function getMereos() {
+	mereosApi = await import('mereos');
+	return mereosApi;
+}
+
+if (import.meta.hot) {
+	import.meta.hot.accept(() => {
+		mereosApi = null;
+	});
+}
+
+function log(message, data) {
+	const time = new Date().toLocaleTimeString();
+	const line = data !== undefined
+		? `[${time}] ${message}\n${JSON.stringify(data, null, 2)}\n`
+		: `[${time}] ${message}\n`;
+	logEl.textContent = line + logEl.textContent;
+}
+
+function mirrorMereosConsoleToPage() {
+	const mirror = (args) => {
+		const first = args[0];
+		const text = typeof first === 'string' ? first.replace(/^%c/, '') : '';
+		if (!text.includes('[mereos]')) return;
+		const data = args.length > 2 ? args[args.length - 1] : (args.length === 2 && typeof args[1] !== 'string' ? args[1] : undefined);
+		log(text.replace('[mereos] ', ''), data);
+	};
+
+	const originalLog = console.log.bind(console);
+	const originalInfo = console.info.bind(console);
+	const originalWarn = console.warn.bind(console);
+	const originalError = console.error.bind(console);
+
+	console.log = (...args) => {
+		originalLog(...args);
+		mirror(args);
+	};
+	console.info = (...args) => {
+		originalInfo(...args);
+		mirror(args);
+	};
+	console.warn = (...args) => {
+		originalWarn(...args);
+		mirror(args);
+	};
+	console.error = (...args) => {
+		originalError(...args);
+		mirror(args);
+	};
+}
+
+mirrorMereosConsoleToPage();
+
+function setStep(step, statusText) {
+	currentStep = step;
+	document.querySelectorAll('.step').forEach((el) => {
+		const stepName = el.dataset.step;
+		el.classList.remove('active', 'done');
+		const order = [FLOW.login, FLOW.prechecks, FLOW.session, FLOW.stop];
+		const currentIdx = order.indexOf(step);
+		const elIdx = order.indexOf(stepName);
+		if (elIdx < currentIdx) el.classList.add('done');
+		if (elIdx === currentIdx) el.classList.add('active');
+	});
+	if (statusText) flowStatusEl.textContent = statusText;
+	updateButtons();
+}
+
+function updateButtons() {
+	btnPrechecks.disabled = !initSucceeded;
+	btnStopPrechecks.disabled = !initSucceeded;
+	btnSession.disabled = !initSucceeded || !prechecksCompleted;
+	btnStopSession.disabled = !sessionStarted;
+}
+
+function buildSchoolTheme() {
+	const mode = darkModeEl.checked ? 'dark' : lightModeEl.checked ? 'light' : 'dark';
+
+	return {
+		language: document.getElementById('language').value,
+		theming: document.getElementById('themeColor').value,
+		mode,
+		font: document.getElementById('fontStyle').value,
+	};
+}
+
+function parseInitPayload() {
+	const raw = initJsonEl.value.trim();
+	const payload = raw ? JSON.parse(raw) : defaultInitPayload;
+
+	const credentials = payload.host || payload.credentials || {
+		client_id: payload.client_id,
+		client_secret: payload.client_secret,
+	};
+
+	const profileId = payload.profileID ?? payload.profileId ?? payload.profile_id;
+	const candidateData = payload.candidateData ?? payload.candidate_object ?? payload.candidate;
+	const assessmentData = payload.assessmentData ?? payload.assessment_object ?? payload.assessment;
+
+	if (!credentials?.client_id || !credentials?.client_secret) {
+		throw new Error('host.client_id and host.client_secret are required');
+	}
+	if (profileId === undefined || profileId === null || profileId === '') {
+		throw new Error('profileID is required');
+	}
+	if (!candidateData) {
+		throw new Error('candidateData is required');
+	}
+	if (!assessmentData) {
+		throw new Error('assessmentData is required');
+	}
+
+	return {
+		credentials,
+		profileId: Number(profileId),
+		candidateData,
+		assessmentData,
+		schoolTheme: buildSchoolTheme(),
+	};
+}
+
+function handlePrechecksCallback(result) {
+	log('prechecks callback', result);
+
+	if (result?.type === 'error') {
+		setStep(FLOW.prechecks, `Prechecks error: ${result.message}. Fix the issue and click Start Prechecks.`);
+		return;
+	}
+
+	if (result?.code === 50001 || result?.message === 'precheck_completed') {
+		prechecksCompleted = true;
+		setStep(FLOW.session, 'Prechecks complete. Click Start Session to begin recording.');
+		log('Prechecks finished — ready for Start Session');
+		return;
+	}
+
+	if (result?.code === 50017 || result?.code === 50018) {
+		setStep(FLOW.prechecks, 'Precheck modal open — complete all steps in the overlay (camera, ID, etc.).');
+	}
+}
+
+async function runPrechecks(resume = false) {
+	const { start_prechecks } = await getMereos();
+	log(resume ? 'Resuming prechecks...' : 'Opening prechecks modal...');
+	setStep(FLOW.prechecks, 'Precheck modal loading — complete all steps in the overlay.');
+
+	const setting = resume ? 'session_resume' : undefined;
+	start_prechecks(handlePrechecksCallback, setting);
+}
+
+async function runInit() {
+	const { init } = await getMereos();
+	const { credentials, profileId, candidateData, assessmentData, schoolTheme } = parseInitPayload();
+
+	log('Calling init...', { profileId, schoolTheme });
+	setStep(FLOW.login, 'Logging in...');
+
+	init(credentials, candidateData, profileId, assessmentData, schoolTheme, async (result) => {
+		log('init callback', result);
+
+		if (result?.type !== 'success') {
+			initSucceeded = false;
+			setStep(FLOW.login, `Login failed: ${result?.message || 'unknown error'}. Check credentials and payload.`);
+			return;
+		}
+
+		initSucceeded = true;
+		prechecksCompleted = false;
+		sessionStarted = false;
+		setStep(FLOW.prechecks, 'Login successful — opening prechecks...');
+
+		try {
+			await runPrechecks(false);
+		} catch (error) {
+			log('Failed to start prechecks after login', { message: error.message });
+			setStep(FLOW.prechecks, 'Login OK but prechecks failed to open. Click Start Prechecks.');
+		}
+	});
+}
+
+btnInit.addEventListener('click', async () => {
+	try {
+		await runInit();
+	} catch (error) {
+		log('Init error', { message: error.message });
+		setStep(FLOW.login, `Error: ${error.message}`);
+	}
+});
+
+btnPrechecks.addEventListener('click', async () => {
+	try {
+		if (!initSucceeded) {
+			log('Run Login first before prechecks');
+			return;
+		}
+		await runPrechecks(true);
+	} catch (error) {
+		log('Error', { message: error.message });
+	}
+});
+
+btnStopPrechecks.addEventListener('click', async () => {
+	try {
+		const { stop_prechecks } = await getMereos();
+		log('Calling stop_prechecks...');
+		stop_prechecks((result) => {
+			log('stop_prechecks callback', result);
+			prechecksCompleted = false;
+			setStep(FLOW.prechecks, 'Prechecks stopped. Click Start Prechecks to open again.');
+		});
+	} catch (error) {
+		log('Error', { message: error.message });
+	}
+});
+
+btnSession.addEventListener('click', async () => {
+	try {
+		const { start_session } = await getMereos();
+		log('Calling start_session...');
+		setStep(FLOW.session, 'Starting proctoring session...');
+
+		start_session((result) => {
+			log('start_session callback', result);
+
+			if (result?.type === 'success') {
+				sessionStarted = true;
+				setStep(FLOW.stop, 'Session running. Click Stop Session when finished.');
+			} else {
+				setStep(FLOW.session, `Session failed: ${result?.message || 'unknown'}. Complete prechecks first if required.`);
+			}
+			updateButtons();
+		});
+	} catch (error) {
+		log('Error', { message: error.message });
+	}
+});
+
+btnStopSession.addEventListener('click', async () => {
+	try {
+		const { stop_session } = await getMereos();
+		log('Calling stop_session...');
+
+		stop_session((result) => {
+			log('stop_session callback', result);
+			sessionStarted = false;
+			initSucceeded = false;
+			prechecksCompleted = false;
+			setStep(FLOW.login, 'Session ended. Click Login to start again.');
+			updateButtons();
+		});
+	} catch (error) {
+		log('Error', { message: error.message });
+	}
+});
+
+setStep(FLOW.login, 'Step 1: Click Login to authenticate and open prechecks.');
+log('Dev playground ready. Login will auto-open prechecks on success.');

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,148 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const LOCAL = path.join(ROOT, '.mereos-local-dev');
+const DEV_ROOT = path.join(LOCAL, 'dev');
+
+let cleanedUp = false;
+let viteProcess = null;
+
+function log(msg) {
+	console.log(`[mereos-dev] ${msg}`);
+}
+
+function writeFile(relPath, content) {
+	const full = path.join(LOCAL, relPath);
+	fs.mkdirSync(path.dirname(full), { recursive: true });
+	fs.writeFileSync(full, content, 'utf8');
+}
+
+const UI_DIR = path.join(__dirname, 'dev-ui');
+
+function readUiTemplate(name) {
+	return fs.readFileSync(path.join(UI_DIR, name), 'utf8');
+}
+
+function createDevAssets() {
+	fs.rmSync(LOCAL, { recursive: true, force: true });
+	fs.mkdirSync(DEV_ROOT, { recursive: true });
+
+	const projectRoot = ROOT.replace(/\\/g, '/');
+
+	const browserCompatPlugin = fs.readFileSync(
+		path.join(UI_DIR, 'browser-compat-plugin.mjs'),
+		'utf8',
+	);
+
+	const mainJs = readUiTemplate('main.js').replaceAll('__PROJECT_ROOT__', projectRoot);
+
+	const viteConfig = `import { defineConfig } from 'vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { browserCompatPlugin } from './browser-compat-plugin.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = ${JSON.stringify(projectRoot)};
+
+export default defineConfig({
+	root: path.join(__dirname, 'dev'),
+	server: {
+		port: 5173,
+		open: true,
+		fs: { allow: [projectRoot, __dirname] },
+		watch: {
+			ignored: ['**/.mereos-local-dev/**'],
+		},
+	},
+	plugins: [browserCompatPlugin(projectRoot)],
+	optimizeDeps: {
+		include: ['twilio-video', '@tensorflow/tfjs', 'i18next'],
+	},
+	resolve: {
+		alias: {
+			mereos: path.join(projectRoot, 'index.js'),
+		},
+	},
+});
+`;
+
+	writeFile('browser-compat-plugin.mjs', browserCompatPlugin);
+	writeFile('dev/defaults.js', readUiTemplate('defaults.js'));
+	writeFile('dev/main.js', mainJs);
+	writeFile('dev/index.html', readUiTemplate('index.html'));
+	writeFile('vite.config.mjs', viteConfig);
+
+	log(`Created temporary dev files in ${LOCAL}`);
+}
+
+function cleanup() {
+	if (cleanedUp) return;
+	cleanedUp = true;
+	log('Stopping — removing local dev files...');
+	fs.rmSync(LOCAL, { recursive: true, force: true });
+	log('Cleanup complete.');
+}
+
+function killViteProcess() {
+	if (!viteProcess || viteProcess.killed) return;
+
+	if (process.platform === 'win32') {
+		spawn('taskkill', ['/pid', String(viteProcess.pid), '/T', '/F'], { stdio: 'ignore', shell: true });
+	} else {
+		viteProcess.kill('SIGTERM');
+	}
+}
+
+function startVite() {
+	const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js');
+	const configPath = path.join(LOCAL, 'vite.config.mjs');
+
+	viteProcess = spawn(process.execPath, [viteBin, '--config', configPath], {
+		cwd: ROOT,
+		stdio: 'inherit',
+		shell: false,
+	});
+
+	viteProcess.on('close', (code) => {
+		cleanup();
+		process.exit(code ?? 0);
+	});
+
+	viteProcess.on('error', (err) => {
+		console.error(err);
+		cleanup();
+		process.exit(1);
+	});
+}
+
+function shutdown() {
+	if (viteProcess && !viteProcess.killed) {
+		killViteProcess();
+	} else {
+		cleanup();
+		process.exit(0);
+	}
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('exit', () => {
+	if (!cleanedUp) cleanup();
+});
+
+try {
+	log('Setting up local development environment...');
+	createDevAssets();
+	log('Starting Vite on http://localhost:5173/');
+	log('Press Ctrl+C to stop — all temporary files will be removed.');
+	log('No source or test files are modified.');
+	startVite();
+} catch (err) {
+	console.error(err);
+	cleanup();
+	process.exit(1);
+}

--- a/src/MobileProctoring/index.js
+++ b/src/MobileProctoring/index.js
@@ -5,7 +5,7 @@ import QRCode from 'qrcode';
 import { closeModal, showTab } from '../ExamsPrechecks';
 import { initSocket } from '../utils/socket';
 import { renderIdentityVerificationSteps } from '../IdentitySteps.js';
-import { convertDataIntoParse, getAuthenticationToken, getDateTime, getSecureFeatures, logger, registerEvent, sentryExceptioMessage, showToast, updatePersistData } from '../utils/functions';
+import { convertDataIntoParse, getAuthenticationToken, getDateTime, getSecureFeatures, logger, registerEvent, releaseAllMediaStreams, sentryExceptioMessage, showToast, updatePersistData } from '../utils/functions';
 import { ASSET_URL } from '../utils/constant';
 import { connectSocketConnection } from '../StartRecording/index.js';
 
@@ -121,9 +121,7 @@ export const MobileProctoring = async (tabContent) => {
 							sessionStatus:'Terminated'
 						});
 						window.mereos.precheckCompleted=false;
-						if(window.mereos.mobileStream){
-							window.mereos.mobileStream.getTracks().forEach(track => track.stop());
-						}
+						void releaseAllMediaStreams();
 						renderUI();
 					} else {
 						logger.error(eventData?.message?.message);
@@ -149,6 +147,7 @@ export const MobileProctoring = async (tabContent) => {
 		try {
 			if (peerInstance) {
 				peerInstance.destroy();
+				peerInstance = null;
 			}
 
 			const groupName = v4();
@@ -156,6 +155,7 @@ export const MobileProctoring = async (tabContent) => {
 			const peer = new Peer(groupName);
 
 			peerInstance = peer;
+			window.mereos.peerInstance = peer;
 
 			peer.on('open', (id) => {
 				logger.success('Peer connection opened with ID:', id);

--- a/src/StartRecording/index.js
+++ b/src/StartRecording/index.js
@@ -1,33 +1,33 @@
-import { 
-	addSectionSessionRecord, 
-	checkForceClosureViolation, 
-	cleanupZendeskWidget, 
-	convertDataIntoParse, 
-	detectBackButton, 
-	detectBackButtonCallback, 
-	detectPageRefresh, 
-	enableCopyPasteCut, 
-	enableTextHighlighting, 
-	findConfigs, 
-	forceClosure, 
-	getDateTime, 
-	getSecureFeatures, 
-	getTimeInSeconds, 
-	getTrackDeviceId, 
-	initializeI18next, 
-	isDevicePresent, 
-	loadZendeskWidget, 
-	lockBrowserFromContent, 
-	logger, 
-	probeExactDevice, 
-	registerAIEvent, 
-	registerEvent, 
+import {
+	addSectionSessionRecord,
+	checkForceClosureViolation,
+	cleanupZendeskWidget,
+	convertDataIntoParse,
+	detectBackButton,
+	detectBackButtonCallback,
+	detectPageRefresh,
+	enableCopyPasteCut,
+	enableTextHighlighting,
+	findConfigs,
+	forceClosure,
+	getDateTime,
+	getSecureFeatures,
+	getTimeInSeconds,
+	getTrackDeviceId,
+	initializeI18next,
+	isDevicePresent,
+	loadZendeskWidget,
+	lockBrowserFromContent,
+	logger,
+	probeExactDevice,
+	registerAIEvent,
+	registerEvent,
 	releaseAllMediaStreams,
-	restoreRightClick, 
-	sentryExceptioMessage, 
-	showToast, 
-	unlockBrowserFromContent, 
-	updatePersistData, 
+	restoreRightClick,
+	sentryExceptioMessage,
+	showToast,
+	unlockBrowserFromContent,
+	updatePersistData,
 	updateThemeColor
 } from '../utils/functions';
 import * as TwilioVideo from 'twilio-video';
@@ -48,35 +48,75 @@ const deviceChangeHandlers = new WeakMap();
 let isMediaError = false;
 let isSignalingError = false;
 
+/*
+ * Notifies the LMS callback stored by start_session. Used at every success/error exit
+ * in this module so the integrator always receives a final result.
+ */
+const invokeStartSessionCallback = (payload) => {
+	if (typeof window.mereos?.startRecordingCallBack === 'function') {
+		window.mereos.startRecordingCallBack(payload);
+	}
+};
+
+/*
+ * Waits for Twilio to publish a local video track (natural event-based wait, no timeout).
+ * Rejects immediately if the room has no participant — avoids a promise that never settles.
+ */
+const waitForParticipantVideoTracks = (room) => {
+	return new Promise((resolve, reject) => {
+		const localParticipant = room?.localParticipant;
+		const videoTracks = localParticipant?.videoTracks;
+
+		if (!localParticipant || !videoTracks) {
+			reject(new Error('Twilio room has no local participant video tracks'));
+			return;
+		}
+
+		if (videoTracks.size > 0) {
+			resolve();
+			return;
+		}
+
+		const onTrackPublished = () => {
+			if (videoTracks.size > 0) {
+				localParticipant.off('trackPublished', onTrackPublished);
+				resolve();
+			}
+		};
+
+		localParticipant.on('trackPublished', onTrackPublished);
+	});
+};
+
 export const initMobileConnection = () => {
 	const session = convertDataIntoParse('session');
-    
+
 	if (window.mereos.mobileRoomInstance) {
 		window.mereos.mobileRoomInstance.disconnect();
 		window.mereos.mobileRoomInstance = null;
 	}
-    
+
 	getCreateRoom({
 		room_name: session?.mobileRoomSessionId,
 		auto_record: false
-	}).then(async (twilioTokens) => {    
+	}).then(async (twilioTokens) => {
 		const twilioRoom = await TwilioVideo.connect(twilioTokens?.data?.token, {
 			audio: false,
 			video: false
 		});
 		window.mereos.mobileRoomInstance = twilioRoom;
-		if(twilioRoom){
+		if (twilioRoom) {
 			VideoChat(twilioRoom);
 		}
 	}).catch((error) => {
 		logger.error('Mobile reconnection failed:', error);
-		registerEvent({ eventType: 'success', notify: false, eventName: 'mobile_connection_failed',eventValue:error });
-		sentryExceptioMessage(error,{type:'error',message:'Mobile connection failed'});
-		if(window.mereos.startRecordingCallBack){
-			window.mereos.startRecordingCallBack({ 
-				type:'error',
+		registerEvent({ eventType: 'success', notify: false, eventName: 'mobile_connection_failed', eventValue: error });
+		sentryExceptioMessage(error, { type: 'error', message: 'Mobile connection failed' });
+		if (window.mereos.startRecordingCallBack) {
+			window.mereos.startRecordingCallBack({
+				type: 'error',
 				message: 'mobile_connection_failed',
-				code:40016
+				code: 40016
 			});
 		}
 	});
@@ -84,15 +124,15 @@ export const initMobileConnection = () => {
 
 export const connectSocketConnection = () => {
 	if (!window.mereos?.socket) {
-		updatePersistData('preChecksSteps', { 
+		updatePersistData('preChecksSteps', {
 			mobileConnection: false,
 			screenSharing: false
 		});
-		if(window.mereos.startRecordingCallBack){
-			window.mereos.startRecordingCallBack({ 
-				type:'error',
-				message: 'mobile_connection_disconnected' ,
-				code:40008
+		if (window.mereos.startRecordingCallBack) {
+			window.mereos.startRecordingCallBack({
+				type: 'error',
+				message: 'mobile_connection_disconnected',
+				code: 40008
 			});
 		}
 		logger.error('Socket not initialized');
@@ -109,32 +149,32 @@ export const connectSocketConnection = () => {
 			}
 
 			case 'violation':
-				if(eventData?.message?.message === 'Violation'){
-					updatePersistData('preChecksSteps', { 
+				if (eventData?.message?.message === 'Violation') {
+					updatePersistData('preChecksSteps', {
 						mobileConnection: false,
 						screenSharing: false
 					});
-					showToast('error','mobile_phone_disconnected');
+					showToast('error', 'mobile_phone_disconnected');
 					const moileElement = document.getElementById('remote-video');
-					if(moileElement){
+					if (moileElement) {
 						moileElement.remove();
 					}
-					if(window.mereos.mobileRoomInstance){
+					if (window.mereos.mobileRoomInstance) {
 						window.mereos.mobileRoomInstance.removeAllListeners();
 						window.mereos.mobileRoomInstance.disconnect();
 						window.mereos.mobileRoomInstance = null;
 					}
-					window.mereos.mobileProctoring=true;
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
+					window.mereos.mobileProctoring = true;
+					if (window.mereos.startRecordingCallBack) {
+						window.mereos.startRecordingCallBack({
+							type: 'error',
 							message: 'mobile_phone_disconnected',
-							code:40010
+							code: 40010
 						});
 					}
 					openModal();
 				}
-				registerEvent({ eventType: 'error', notify: false, eventName:'mobile_phone_disconnected' , eventValue: getDateTime() });
+				registerEvent({ eventType: 'error', notify: false, eventName: 'mobile_phone_disconnected', eventValue: getDateTime() });
 				break;
 
 			default:
@@ -142,7 +182,7 @@ export const connectSocketConnection = () => {
 				break;
 		}
 	};
-		
+
 	window.mereos.socket.onerror = (error) => {
 		logger.error('WebSocket error:', error);
 	};
@@ -150,24 +190,24 @@ export const connectSocketConnection = () => {
 
 const cleanupCameraTracks = async (room, trackKind) => {
 	const existingTracks = Array.from(
-		trackKind === 'video' 
-			? room.localParticipant.videoTracks.values() 
+		trackKind === 'video'
+			? room.localParticipant.videoTracks.values()
 			: room.localParticipant.audioTracks.values()
 	);
-    
+
 	for (const trackPublication of existingTracks) {
 		if (trackPublication.track && trackPublication.track.kind === trackKind) {
 			if (trackKind === 'video' && (
-				trackPublication.track.name?.includes('screen') || 
-                trackPublication === window.mereos?.screenTrackPublished
+				trackPublication.track.name?.includes('screen') ||
+				trackPublication === window.mereos?.screenTrackPublished
 			)) {
 				continue;
 			}
-            
+
 			if (typeof trackStoppedListeners !== 'undefined' && trackStoppedListeners.has(trackPublication.track)) {
 				trackStoppedListeners.delete(trackPublication.track);
 			}
-            
+
 			try {
 				await room.localParticipant.unpublishTrack(trackPublication.track);
 				trackPublication.track.stop();
@@ -182,7 +222,7 @@ const cleanupCameraTracks = async (room, trackKind) => {
 
 export const showPermissionModal = (permissionType = 'camera') => {
 	let container, existingModal;
-    
+
 	if (window.mereos?.shadowRoot) {
 		container = window.mereos.shadowRoot;
 		existingModal = container.getElementById('permissionModal');
@@ -190,7 +230,7 @@ export const showPermissionModal = (permissionType = 'camera') => {
 		container = document.body;
 		existingModal = document.getElementById('permissionModal');
 	}
-    
+
 	if (existingModal) {
 		existingModal.remove();
 	}
@@ -199,45 +239,45 @@ export const showPermissionModal = (permissionType = 'camera') => {
 	modalDiv.id = 'permissionModal';
 	modalDiv.className = 'permission-modal-overlay';
 	modalDiv.setAttribute('data-permission-type', permissionType);
-    
+
 	// Set content based on permission type
-	const modalTitle = permissionType === 'camera' 
-		? i18next.t('camera_access_lost') 
+	const modalTitle = permissionType === 'camera'
+		? i18next.t('camera_access_lost')
 		: i18next.t('microphone_access_lost');
-    
+
 	const modalDescription = permissionType === 'camera'
 		? i18next.t('your_camera_access_has_been_disabled_during_the_session')
 		: i18next.t('your_microphone_access_has_been_disabled_during_the_session');
-    
+
 	const step1Text = permissionType === 'camera'
 		? i18next.t('click_the_camera_icon')
 		: i18next.t('click_the_microphone_icon');
-    
+
 	const step2Text = permissionType === 'camera'
 		? i18next.t('select_allow_for_camera_access')
 		: i18next.t('select_allow_for_microphone_access');
-    
+
 	const buttonText = permissionType === 'camera'
 		? i18next.t('reconnect_camera')
 		: i18next.t('reconnect_microphone');
-    
+
 	const alternativeMethodTitle = permissionType === 'camera'
 		? i18next.t('alternative_method')
 		: i18next.t('alternative_method_microphone');
-    
+
 	// Browser instructions based on permission type
 	const chromeInstructions = permissionType === 'camera'
 		? i18next.t('settings_camera_steps')
 		: i18next.t('settings_microphone_steps');
-    
+
 	const firefoxInstructions = permissionType === 'camera'
 		? i18next.t('firefox_camera_steps')
 		: i18next.t('firefox_microphone_steps');
-    
+
 	const safariInstructions = permissionType === 'camera'
 		? i18next.t('safari_camera_step')
 		: i18next.t('safari_microphone_step');
-    
+
 	modalDiv.innerHTML = `
         <div class="permission-modal">
             <div class="permission-modal-header">
@@ -249,7 +289,7 @@ export const showPermissionModal = (permissionType = 'camera') => {
                     <ol>
                         <li>${step1Text}</li>
                         <li>${step2Text}</li>
-                        <li>${permissionType === 'camera' ? i18next.t('click_reconnect_camera'): i18next.t('click_reconnect_microphone')}</li>
+                        <li>${permissionType === 'camera' ? i18next.t('click_reconnect_camera') : i18next.t('click_reconnect_microphone')}</li>
                     </ol>
                     
                     <div class="browser-instructions">
@@ -270,27 +310,27 @@ export const showPermissionModal = (permissionType = 'camera') => {
             </div>
         </div>
     `;
-    
+
 	try {
 		container.appendChild(modalDiv);
 	} catch (error) {
 		document.body.appendChild(modalDiv);
 	}
-    
+
 	document.body.style.overflow = 'hidden';
-    
+
 	addModalEventListeners();
 };
 
 const hidePermissionModal = () => {
 	let modal;
-    
+
 	if (window.mereos?.shadowRoot) {
 		modal = window.mereos.shadowRoot.getElementById('permissionModal');
 	} else {
 		modal = document.getElementById('permissionModal');
 	}
-    
+
 	if (modal) {
 		modal.remove();
 	}
@@ -299,22 +339,22 @@ const hidePermissionModal = () => {
 
 const addModalEventListeners = () => {
 	let modal;
-    
+
 	if (window.mereos?.shadowRoot) {
 		modal = window.mereos.shadowRoot.getElementById('permissionModal');
 	} else {
 		modal = document.getElementById('permissionModal');
 	}
-    
+
 	if (!modal) return;
 
 	const reconnectBtn = modal.querySelector('#reconnectBtn');
-    
+
 	if (reconnectBtn) {
 		reconnectBtn.addEventListener('click', reconnectCamera);
 	}
-    
-	modal.addEventListener('click', function(e) {
+
+	modal.addEventListener('click', function (e) {
 		if (e.target === modal) {
 			hidePermissionModal();
 		}
@@ -323,7 +363,7 @@ const addModalEventListeners = () => {
 
 // ============= DEVICE HANDLING FUNCTIONS =============
 
-const handleDeviceLost = (kind, isUserDisabled = false, track,trackType) => {
+const handleDeviceLost = (kind, isUserDisabled = false, track, trackType) => {
 	if (track.name.includes('screen-share')) return;
 
 	const container = window.mereos?.shadowRoot || document;
@@ -336,8 +376,8 @@ const handleDeviceLost = (kind, isUserDisabled = false, track,trackType) => {
 	}
 
 	// Show appropriate modal based on device kind
-	if (typeof showPermissionModal === 'function' && 
-        session?.sessionStatus === 'Attending') {
+	if (typeof showPermissionModal === 'function' &&
+		session?.sessionStatus === 'Attending') {
 		showPermissionModal(trackType);
 	}
 
@@ -351,13 +391,13 @@ const handleDeviceLost = (kind, isUserDisabled = false, track,trackType) => {
 
 	if (typeof registerEvent === 'function' && session.sessionStatus === 'Attending') {
 		let eventName;
-        
+
 		if (isUserDisabled) {
 			eventName = kind === 'video' ? 'camera_permission_denied_hardware' : 'microphone_permission_denied_hardware';
 		} else {
 			eventName = kind === 'video' ? 'camera_permission_disabled' : 'microphone_permission_denied';
 		}
-        
+
 		registerEvent({
 			eventType: 'error',
 			notify: false,
@@ -375,7 +415,7 @@ const detachDeviceChangeWatcher = (track) => {
 	}
 };
 
-const setupTrackStoppedListeners = (track,trackType) => {
+const setupTrackStoppedListeners = (track, trackType) => {
 	const session = convertDataIntoParse('session');
 	const stoppedListener = async () => {
 		const kind = track.kind;
@@ -386,19 +426,19 @@ const setupTrackStoppedListeners = (track,trackType) => {
 			if (mst && mst.readyState === 'ended') {
 				const present = await isDevicePresent(kind, deviceId);
 				if (!present) {
-					handleDeviceLost(kind, false, track,trackType);
+					handleDeviceLost(kind, false, track, trackType);
 					return;
 				}
 			}
 
 			await probeExactDevice(kind, deviceId);
-			handleDeviceLost(kind, true, track,trackType);
+			handleDeviceLost(kind, true, track, trackType);
 		} catch (probeError) {
 			logger?.error?.(`Exact-device probe failed for ${kind}`, probeError);
 			if (probeError.name === 'NotAllowedError') {
-				handleDeviceLost(kind, false, track,trackType);
+				handleDeviceLost(kind, false, track, trackType);
 			} else if (probeError.name === 'NotReadableError') {
-				handleDeviceLost(kind, true, track,trackType);
+				handleDeviceLost(kind, true, track, trackType);
 			}
 			sentryExceptioMessage(probeError, { type: 'error', message: probeError.name });
 		} finally {
@@ -416,7 +456,7 @@ const setupTrackStoppedListeners = (track,trackType) => {
 const removeStoppedListener = (track) => {
 	const fn = trackStoppedListeners.get(track);
 	if (fn) {
-		try { track.off('stopped', fn); } catch {}
+		try { track.off('stopped', fn); } catch { }
 		trackStoppedListeners.delete(track);
 	}
 	detachDeviceChangeWatcher(track);
@@ -425,10 +465,10 @@ const removeStoppedListener = (track) => {
 // ============= RECONNECT FUNCTION =============
 
 const reconnectCamera = async () => {
-	try {        
+	try {
 		if (!window.mereos?.roomInstance) {
 			if (window.mereos.startRecordingCallBack) {
-				window.mereos.startRecordingCallBack({ 
+				window.mereos.startRecordingCallBack({
 					type: 'error',
 					message: 'no_active_session_found',
 					code: 40021
@@ -436,64 +476,64 @@ const reconnectCamera = async () => {
 			}
 			return;
 		}
-        
+
 		hidePermissionModal();
-        
+
 		const secureFeatures = getSecureFeatures();
 		const session = convertDataIntoParse('session');
 		const room = window.mereos.roomInstance;
-        
+
 		const mediaConstraints = {};
 		let needsVideo = false;
 		let needsAudio = false;
-        
+
 		if (findConfigs(['record_video'], secureFeatures?.entities).length) {
-			mediaConstraints.video = localStorage.getItem('deviceId') 
-				? { deviceId: { exact: localStorage.getItem('deviceId') } } 
+			mediaConstraints.video = localStorage.getItem('deviceId')
+				? { deviceId: { exact: localStorage.getItem('deviceId') } }
 				: true;
 			needsVideo = true;
 		}
-        
+
 		if (findConfigs(['record_audio'], secureFeatures?.entities).length) {
-			mediaConstraints.audio = localStorage.getItem('microphoneID') 
-				? { deviceId: { exact: localStorage.getItem('microphoneID') } } 
+			mediaConstraints.audio = localStorage.getItem('microphoneID')
+				? { deviceId: { exact: localStorage.getItem('microphoneID') } }
 				: true;
 			needsAudio = true;
 		} else {
 			mediaConstraints.audio = false;
 		}
-        
+
 		if (!needsVideo && !needsAudio) {
 			return;
 		}
-        
+
 		const mediaStream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
-        
+
 		if (needsVideo) {
 			await cleanupCameraTracks(room, 'video');
 		}
 		if (needsAudio) {
 			await cleanupCameraTracks(room, 'audio');
 		}
-        
+
 		const videoTrack = mediaStream.getVideoTracks()[0];
 		const audioTrack = mediaStream.getAudioTracks()[0];
-        
+
 		let newVideoTrackPublication, newAudioTrackPublication;
 		let cameraRecordings = [...(session.user_video_name || [])];
 		let audioRecordings = [...(session.user_audio_name || [])];
-        
+
 		if (videoTrack && needsVideo) {
 			const twilioVideoTrack = new TwilioVideo.LocalVideoTrack(videoTrack);
 			newVideoTrackPublication = await room.localParticipant.publishTrack(twilioVideoTrack);
-            
+
 			cameraRecordings.push(newVideoTrackPublication.trackSid);
-            
+
 			await new Promise(resolve => setTimeout(resolve, 100));
 			hidePermissionModal();
 			const localVideoTrack = Array.from(room.localParticipant.videoTracks.values())
 				.find(publication => publication.trackSid === newVideoTrackPublication.trackSid)?.track;
-            
+
 			if (localVideoTrack) {
 				const twilioStream = new MediaStream([localVideoTrack.mediaStreamTrack]);
 				hidePermissionModal();
@@ -503,20 +543,20 @@ const reconnectCamera = async () => {
 					await setupWebcam(twilioStream);
 				}
 			}
-            
+
 			setupTrackStoppedListeners(twilioVideoTrack);
 		}
-        
+
 		if (audioTrack && needsAudio) {
 			const twilioAudioTrack = new TwilioVideo.LocalAudioTrack(audioTrack);
 			newAudioTrackPublication = await room.localParticipant.publishTrack(twilioAudioTrack);
-            
+
 			audioRecordings.push(newAudioTrackPublication.trackSid);
-            
+
 			setupTrackStoppedListeners(twilioAudioTrack);
 			console.log('Audio track reconnected with stopped listener');
 		}
-        
+
 		const updateData = {};
 		if (newVideoTrackPublication) {
 			updateData.user_video_name = cameraRecordings;
@@ -524,51 +564,51 @@ const reconnectCamera = async () => {
 		if (newAudioTrackPublication) {
 			updateData.user_audio_name = audioRecordings;
 		}
-        
+
 		if (Object.keys(updateData).length > 0) {
 			updatePersistData('session', updateData);
 		}
-        
+
 		if (typeof registerEvent === 'function') {
-			registerEvent({ 
-				eventType: 'success', 
-				notify: false, 
-				eventName: 'permission_restored', 
-				eventValue: new Date() 
+			registerEvent({
+				eventType: 'success',
+				notify: false,
+				eventName: 'permission_restored',
+				eventValue: new Date()
 			});
 			hidePermissionModal();
 		}
-        
+
 		if (window.mereos.startRecordingCallBack) {
-			window.mereos.startRecordingCallBack({ 
+			window.mereos.startRecordingCallBack({
 				type: 'success',
 				message: 'device_reconnected_successfully',
 				code: 50000
 			});
 		}
-        
+
 	} catch (error) {
 		// Determine which permission was denied
 		const errorMessage = error.message?.toLowerCase() || '';
 		const errorName = error.name?.toLowerCase() || '';
-        
+
 		let permissionType = 'camera'; // Default
-        
-		if (errorMessage.includes('audio') || errorMessage.includes('microphone') || 
-            errorName.includes('audio') || errorName.includes('microphone')) {
+
+		if (errorMessage.includes('audio') || errorMessage.includes('microphone') ||
+			errorName.includes('audio') || errorName.includes('microphone')) {
 			permissionType = 'microphone';
 		} else if (errorMessage.includes('video') || errorMessage.includes('camera') ||
-                   errorName.includes('video') || errorName.includes('camera')) {
+			errorName.includes('video') || errorName.includes('camera')) {
 			permissionType = 'camera';
 		}
-        
+
 		if (error.name === 'NotAllowedError' || error.name === 'PermissionDeniedError') {
 			setTimeout(() => {
 				showPermissionModal(permissionType);
 			}, 500);
-            
+
 			if (window.mereos.startRecordingCallBack) {
-				window.mereos.startRecordingCallBack({ 
+				window.mereos.startRecordingCallBack({
 					type: 'error',
 					message: permissionType === 'camera' ? 'camera_permission_denied' : 'microphone_permission_denied',
 					code: 40019
@@ -580,7 +620,7 @@ const reconnectCamera = async () => {
 				updatePersistData('session', {
 					sessionStatus: 'Terminated'
 				});
-				window.mereos.startRecordingCallBack({ 
+				window.mereos.startRecordingCallBack({
 					type: 'error',
 					message: 'device_reconnection_failed',
 					code: 40022
@@ -589,12 +629,12 @@ const reconnectCamera = async () => {
 		}
 
 		await releaseAllMediaStreams();
-        
+
 		if (typeof registerEvent === 'function') {
-			registerEvent({ 
-				eventType: 'error', 
-				notify: false, 
-				eventName: permissionType === 'camera' ? 'camera_reconnection_failed' : 'microphone_reconnection_failed', 
+			registerEvent({
+				eventType: 'error',
+				notify: false,
+				eventName: permissionType === 'camera' ? 'camera_reconnection_failed' : 'microphone_reconnection_failed',
 				eventValue: new Date(),
 				errorMessage: error.message
 			});
@@ -609,7 +649,12 @@ if (typeof document !== 'undefined') {
 	document.head.appendChild(styleElement);
 }
 
-export const startRecording = async () => {	
+/**
+ * Connects Twilio, publishes tracks, and persists session to the backend.
+ * Called by start_session after room tokens are ready.
+ * LMS callback (recording_started_successfully or error) fires before addSectionSessionRecord.
+ */
+export const startRecording = async () => {
 	let screenTrack = null;
 	let cameraRecordings = [];
 	let audioRecordings = [];
@@ -617,12 +662,12 @@ export const startRecording = async () => {
 	const secureFeatures = getSecureFeatures();
 	const session = convertDataIntoParse('session');
 	const candidateInviteAssessmentSection = convertDataIntoParse('candidateAssessment');
-	
+
 	detectPageRefresh();
 	detectBackButton();
-	
+
 	let libraryDOM = document.getElementById('mereos-library');
-	if(!libraryDOM){
+	if (!libraryDOM) {
 		initShadowDOM();
 		updateThemeColor();
 	}
@@ -632,407 +677,436 @@ export const startRecording = async () => {
 	}
 
 	loadZendeskWidget();
-	if(findConfigs(['mobile_proctoring'], secureFeatures?.entities).length && window?.mereos?.mobileStream){
+	if (findConfigs(['mobile_proctoring'], secureFeatures?.entities).length && window?.mereos?.mobileStream) {
 		connectSocketConnection();
 	}
 
 	if (
 		(!window.mereos?.newStream || window?.mereos?.newStream?.getTracks()?.length === 0) &&
 		findConfigs(['record_screen'], secureFeatures?.entities)?.length > 0
-	) {		
-		await registerEvent({ 
-			eventType: 'error', 
-			notify: false, 
-			eventName: 'screen_recording_not_started', 
+	) {
+		await registerEvent({
+			eventType: 'error',
+			notify: false,
+			eventName: 'screen_recording_not_started',
 		});
 		if (window.mereos.startRecordingCallBack) {
-			window.mereos.startRecordingCallBack({ 
-				type:'error',
-				message: 'please_share_your_screen' ,
-				code:40011
+			window.mereos.startRecordingCallBack({
+				type: 'error',
+				message: 'please_share_your_screen',
+				code: 40011
 			});
 		}
-		window.mereos.recordingStart=false;
-		window.mereos.precheckCompleted=false;
+		window.mereos.recordingStart = false;
+		window.mereos.precheckCompleted = false;
 		return;
 	}
 
-	const fullscreenRequired = secureFeatures?.entities?.some(entity => entity.key === 'force_full_screen');
+	/*
+	 * Outer try/catch: lockdown, fullscreen, and addSectionSessionRecord were previously
+	 * outside the inner Twilio try — failures there never invoked the LMS callback.
+	 */
+	try {
+		const fullscreenRequired = secureFeatures?.entities?.some(entity => entity.key === 'force_full_screen');
 
-	if(secureFeatures?.entities?.filter(entity => LockDownOptions.includes(entity.key))?.length){
-		await lockBrowserFromContent(secureFeatures?.entities || []);
-	}
+		if (secureFeatures?.entities?.filter(entity => LockDownOptions.includes(entity.key))?.length) {
+			await lockBrowserFromContent(secureFeatures?.entities || []);
+		}
 
-	if (fullscreenRequired) {
-		const cleanupForceFullscreen = initializeForceFullscreen();
-    
-		window.mereos.cleanupForceFullscreen = cleanupForceFullscreen;
-	}
+		if (fullscreenRequired) {
+			const cleanupForceFullscreen = initializeForceFullscreen();
 
-	if (secureFeatures?.entities.filter(entity => recordingEvents.includes(entity.key))?.length > 0) {
+			window.mereos.cleanupForceFullscreen = cleanupForceFullscreen;
+		}
 
-		let twilioOptions = {
-			preferredVideoCodecs: 'auto', 
-			bandwidthProfile: { 
-				video: {
-					contentPreferencesMode: 'auto',
-					clientTrackSwitchOffControl: 'auto'
-				}
-			},
-			networkQuality: { 
-				local: 3, 
-				remote: 3 
-			},
-			audio: findConfigs(['record_audio'], secureFeatures?.entities).length ?
-				(localStorage.getItem('microphoneID') !== null ? {
-					deviceId: { exact: localStorage.getItem('microphoneID') },
-				} : true)
-				:
-				false,
-			video: findConfigs(['record_video'], secureFeatures?.entities).length ?
-				(localStorage.getItem('deviceId') !== null ? {
-					deviceId: { exact: localStorage.getItem('deviceId') },
-				} : true)
-				:
-				false
-		};
+		if (secureFeatures?.entities.filter(entity => recordingEvents.includes(entity.key))?.length > 0) {
 
-		[window.mereos.globalStream, window.mereos.audioStream].forEach((stream) => {
-			stream?.getTracks?.().forEach((track) => {
-				try {
-					track.stop();
-				} catch (error) {
-					logger.error('Failed to stop precheck media track:', error);
-				}
+			let twilioOptions = {
+				preferredVideoCodecs: 'auto',
+				bandwidthProfile: {
+					video: {
+						contentPreferencesMode: 'auto',
+						clientTrackSwitchOffControl: 'auto'
+					}
+				},
+				networkQuality: {
+					local: 3,
+					remote: 3
+				},
+				audio: findConfigs(['record_audio'], secureFeatures?.entities).length ?
+					(localStorage.getItem('microphoneID') !== null ? {
+						deviceId: { exact: localStorage.getItem('microphoneID') },
+					} : true)
+					:
+					false,
+				video: findConfigs(['record_video'], secureFeatures?.entities).length ?
+					(localStorage.getItem('deviceId') !== null ? {
+						deviceId: { exact: localStorage.getItem('deviceId') },
+					} : true)
+					:
+					false
+			};
+
+			[window.mereos.globalStream, window.mereos.audioStream].forEach((stream) => {
+				stream?.getTracks?.().forEach((track) => {
+					try {
+						track.stop();
+					} catch (error) {
+						logger.error('Failed to stop precheck media track:', error);
+					}
+				});
 			});
-		});
-		window.mereos.globalStream = null;
-		window.mereos.audioStream = null;
+			window.mereos.globalStream = null;
+			window.mereos.audioStream = null;
 
-		try {
-			const newRoomSessionId = v4();
-			const newSessionId = session?.sessionId ? session?.sessionId : v4();
-			
-			updatePersistData('session', {
-				roomSessionId: newRoomSessionId,
-				sessionId: newSessionId,
-				sessionStatus:'Attending'
-			});
-			let room;
-			try{
-				room = await TwilioVideo.connect(session?.twilioToken, twilioOptions);
-				window.mereos.roomInstance = room;
-			}catch(error){
-				await releaseAllMediaStreams();
-				if (error.code) {
-					logger.error('Twilio error code:', error.code);
-				}
-				if (error.message) {
-					logger.error('Twilio error message:', error.message);
-				}
+			/*
+			 * Re-read session from localStorage so connect uses the token set by start_session
+			 * (new fetch or session_resume reuse). `session` above is kept for recording history arrays.
+			 */
+			const persistedSession = convertDataIntoParse('session');
+			if (!persistedSession?.twilioToken) {
+				window.mereos.recordingStart = false;
 				registerEvent({ eventType: 'success', notify: false, eventName: 'room_is_not_creating' });
-				sentryExceptioMessage(error,{type:'error',message:'Twilio room is not creating'});
-				if(window.mereos.startRecordingCallBack){
-					window.mereos.startRecordingCallBack({ 
-						type:'error',
-						message: 'room_is_not_creating',
-						code:40065,
-					});
-				}	
-			}
-			updatePersistData('session', { 
-				room_id: room?.sid 
-			});
-
-			const mediaConstraints = {};
-
-			if (findConfigs(['record_video'], secureFeatures?.entities).length) {
-				mediaConstraints.video = localStorage.getItem('deviceId') 
-					? { deviceId: { exact: localStorage.getItem('deviceId') } } 
-					: true;
-			}
-
-			if (findConfigs(['record_audio'], secureFeatures?.entities).length) {
-				mediaConstraints.audio = localStorage.getItem('microphoneID') 
-					? { deviceId: { exact: localStorage.getItem('microphoneID') } } 
-					: true;
-			} else {
-				mediaConstraints.audio = false;
-			}
-			if(secureFeatures?.entities?.find(entity => entity.key === 'record_video')){
-				await new Promise((resolve) => {
-					if(room.localParticipant.videoTracks){
-						if (room.localParticipant.videoTracks.size > 0) {
-							resolve();
-						} else {
-							const checkTracks = () => {
-								if (room.localParticipant.videoTracks.size > 0) {
-									room.localParticipant.off('trackPublished', checkTracks);
-									resolve();
-								}
-							};
-							room.localParticipant.on('trackPublished', checkTracks);
-						}
-					}
+				invokeStartSessionCallback({
+					type: 'error',
+					message: 'room_is_not_creating',
+					code: 40065,
+					details: 'Twilio token is missing',
 				});
+				return;
+			}
 
-				const localVideoTrack = Array.from(room.localParticipant.videoTracks.values())[0]?.track;
-				
-				if (localVideoTrack) {
-					const twilioStream = new MediaStream([localVideoTrack.mediaStreamTrack]);
-					
-					if(secureFeatures?.entities?.filter(entity => aiEventsFeatures.includes(entity.key))?.length){
-						await startAIWebcam(room, twilioStream);
-					} else {
-						await setupWebcam(twilioStream);
-					}
-				} 
+			try {
+				const newRoomSessionId = v4();
+				const newSessionId = session?.sessionId ? session?.sessionId : v4();
 
-				cameraRecordings = [
-					...session.user_video_name,
-					...Array.from(room?.localParticipant?.videoTracks, ([name, value]) => ({ name, value })).map(rt => rt.name)
-				];
-
-				updatePersistData('session', { 
-					user_video_name: cameraRecordings || [], 
+				updatePersistData('session', {
+					roomSessionId: newRoomSessionId,
+					sessionId: newSessionId,
+					sessionStatus: 'Attending'
 				});
-			}
-
-			if(findConfigs(['record_audio'], secureFeatures?.entities).length){
-				audioRecordings = [
-					...session.user_audio_name,
-					...Array.from(room?.localParticipant?.audioTracks, ([name, value]) => ({ name, value })).map(rt => rt.name)
-				];
-				updatePersistData('session', { user_audio_name: audioRecordings, room_id: room?.sid });
-			}
-
-			if (session?.screenRecordingStream && findConfigs(['record_screen'], secureFeatures?.entities).length) {
-				if(window.mereos?.newStream?.getTracks()[0]){
-					screenTrack = new TwilioVideo.LocalVideoTrack(window?.mereos?.newStream?.getTracks()[0],{
-						name: `screen-share-${v4()}`
-					});
-					window.mereos.screenTrackPublished = await room.localParticipant.publishTrack(screenTrack);
-					screenRecordings = [...session.screen_sharing_video_name, window.mereos.screenTrackPublished.trackSid];
-					updatePersistData('session', { screen_sharing_video_name: screenRecordings });
-				}else{
-					await registerEvent({ 
-						eventType: 'error', 
-						notify: false, 
-						eventName: 'screen_recording_not_started', 
-					});
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
-							message: 'please_share_your_screen',
-							code:40011 
-						});
+				let room;
+				try {
+					room = await TwilioVideo.connect(persistedSession.twilioToken, twilioOptions);
+					window.mereos.roomInstance = room;
+				} catch (error) {
+					await releaseAllMediaStreams();
+					if (error.code) {
+						logger.error('Twilio error code:', error.code);
 					}
-					window.mereos.precheckCompleted=false;
+					if (error.message) {
+						logger.error('Twilio error message:', error.message);
+					}
+					registerEvent({ eventType: 'success', notify: false, eventName: 'room_is_not_creating' });
+					sentryExceptioMessage(error, { type: 'error', message: 'Twilio room is not creating' });
 					window.mereos.recordingStart = false;
+					invokeStartSessionCallback({
+						type: 'error',
+						message: 'room_is_not_creating',
+						code: 40065,
+					});
+					// Must return here — previously execution continued with room === undefined.
 					return;
 				}
-			}
-			
-			if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
-				window.mereos.socket.send(JSON.stringify({ event: 'startRecording', data: 'Web video recording started' }));
-			}
-
-			const localParticipant = room?.localParticipant;
-
-			localParticipant.on('networkQualityLevelChanged', (level) => {
-				if (level <= 2) {
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
-							message: 'session_is_terminated_due_to_slow_internet_connection',
-							code:40013
-						});
-					}
-
-					registerEvent({ eventType: 'error', notify: false, eventName: 'slow_internet_detected' });
-				
-					// showToast('error','your_internet_is_very_slow_please_make_sure_you_have_stable_network_quality');
-				}
-			});
-			
-			room?.localParticipant?.videoTracks.forEach(({ track }) => {
-				if (track && track.kind === 'video') {
-					setupTrackStoppedListeners(track, 'video');
-				}
-			});
-
-			room?.localParticipant?.audioTracks.forEach(({ track }) => {
-				if (track && track.kind === 'audio') {
-					setupTrackStoppedListeners(track, 'microphone');
-				}
-			});
-
-			const handleReconnecting = async (error) => {
-				if (
-					error?.message?.includes('Media connection failed') ||
-				error?.message?.includes('Media activity')
-				) {
-					registerEvent({
-						notify: false,
-						eventName: 'media_connection_failed',
-					});
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
-							message: 'media_connection_failed',
-							code:40056
-						});
-					}
-					showToast('error','internet_connection_lost');
-					isMediaError = true;
-				} else if (
-					error?.message?.includes('Signaling connection disconnected')
-				) {
-					registerEvent({
-						notify: false,
-						eventName: 'signaling_connection_disconnected',
-					});
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
-							message: 'signaling_connection_disconnected',
-							code:40057
-						});
-					}
-					showToast('error','reconnecting_signaling_connection');
-					isSignalingError = true;
-				} else {
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'success',
-							message: 'video_recording_reconnecting',
-							code:50019
-						});
-					}
-					registerEvent({
-						notify: false,
-						eventName: 'video_recording_reconnecting',
-					});
-				}
-			};
-
-			const handleDisconnected = async () => {
-				cleanupLocalVideo();
-				registerEvent({
-					notify: false,
-					eventName: 'video_recording_disconnected',
+				updatePersistData('session', {
+					room_id: room?.sid
 				});
-				
-				updatePersistData('session', { 
+
+				const mediaConstraints = {};
+
+				if (findConfigs(['record_video'], secureFeatures?.entities).length) {
+					mediaConstraints.video = localStorage.getItem('deviceId')
+						? { deviceId: { exact: localStorage.getItem('deviceId') } }
+						: true;
+				}
+
+				if (findConfigs(['record_audio'], secureFeatures?.entities).length) {
+					mediaConstraints.audio = localStorage.getItem('microphoneID')
+						? { deviceId: { exact: localStorage.getItem('microphoneID') } }
+						: true;
+				} else {
+					mediaConstraints.audio = false;
+				}
+				if (secureFeatures?.entities?.find(entity => entity.key === 'record_video')) {
+					await waitForParticipantVideoTracks(room);
+
+					const localVideoTrack = Array.from(room.localParticipant.videoTracks.values())[0]?.track;
+
+					if (localVideoTrack) {
+						const twilioStream = new MediaStream([localVideoTrack.mediaStreamTrack]);
+
+						if (secureFeatures?.entities?.filter(entity => aiEventsFeatures.includes(entity.key))?.length) {
+							const aiResult = await startAIWebcam(room, twilioStream);
+							// startAIWebcam fires its own error callback; do not also send success below.
+							if (aiResult?.success === false) {
+								window.mereos.recordingStart = false;
+								return;
+							}
+						} else {
+							await setupWebcam(twilioStream);
+						}
+					}
+
+					cameraRecordings = [
+						...session.user_video_name,
+						...Array.from(room?.localParticipant?.videoTracks, ([name, value]) => ({ name, value })).map(rt => rt.name)
+					];
+
+					updatePersistData('session', {
+						user_video_name: cameraRecordings || [],
+					});
+				}
+
+				if (findConfigs(['record_audio'], secureFeatures?.entities).length) {
+					audioRecordings = [
+						...session.user_audio_name,
+						...Array.from(room?.localParticipant?.audioTracks, ([name, value]) => ({ name, value })).map(rt => rt.name)
+					];
+					updatePersistData('session', { user_audio_name: audioRecordings, room_id: room?.sid });
+				}
+
+				if (session?.screenRecordingStream && findConfigs(['record_screen'], secureFeatures?.entities).length) {
+					if (window.mereos?.newStream?.getTracks()[0]) {
+						screenTrack = new TwilioVideo.LocalVideoTrack(window?.mereos?.newStream?.getTracks()[0], {
+							name: `screen-share-${v4()}`
+						});
+						window.mereos.screenTrackPublished = await room.localParticipant.publishTrack(screenTrack);
+						screenRecordings = [...session.screen_sharing_video_name, window.mereos.screenTrackPublished.trackSid];
+						updatePersistData('session', { screen_sharing_video_name: screenRecordings });
+					} else {
+						await registerEvent({
+							eventType: 'error',
+							notify: false,
+							eventName: 'screen_recording_not_started',
+						});
+						if (window.mereos.startRecordingCallBack) {
+							invokeStartSessionCallback({
+								type: 'error',
+								message: 'please_share_your_screen',
+								code: 40011
+							});
+						}
+						window.mereos.precheckCompleted = false;
+						window.mereos.recordingStart = false;
+						return;
+					}
+				}
+
+				if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
+					window.mereos.socket.send(JSON.stringify({ event: 'startRecording', data: 'Web video recording started' }));
+				}
+
+				const localParticipant = room?.localParticipant;
+
+				localParticipant.on('networkQualityLevelChanged', (level) => {
+					if (level <= 2) {
+						if (window.mereos.startRecordingCallBack) {
+							window.mereos.startRecordingCallBack({
+								type: 'error',
+								message: 'session_is_terminated_due_to_slow_internet_connection',
+								code: 40013
+							});
+						}
+
+						registerEvent({ eventType: 'error', notify: false, eventName: 'slow_internet_detected' });
+
+						// showToast('error','your_internet_is_very_slow_please_make_sure_you_have_stable_network_quality');
+					}
+				});
+
+				room?.localParticipant?.videoTracks.forEach(({ track }) => {
+					if (track && track.kind === 'video') {
+						setupTrackStoppedListeners(track, 'video');
+					}
+				});
+
+				room?.localParticipant?.audioTracks.forEach(({ track }) => {
+					if (track && track.kind === 'audio') {
+						setupTrackStoppedListeners(track, 'microphone');
+					}
+				});
+
+				const handleReconnecting = async (error) => {
+					if (
+						error?.message?.includes('Media connection failed') ||
+						error?.message?.includes('Media activity')
+					) {
+						registerEvent({
+							notify: false,
+							eventName: 'media_connection_failed',
+						});
+						if (window.mereos.startRecordingCallBack) {
+							window.mereos.startRecordingCallBack({
+								type: 'error',
+								message: 'media_connection_failed',
+								code: 40056
+							});
+						}
+						showToast('error', 'internet_connection_lost');
+						isMediaError = true;
+					} else if (
+						error?.message?.includes('Signaling connection disconnected')
+					) {
+						registerEvent({
+							notify: false,
+							eventName: 'signaling_connection_disconnected',
+						});
+						if (window.mereos.startRecordingCallBack) {
+							window.mereos.startRecordingCallBack({
+								type: 'error',
+								message: 'signaling_connection_disconnected',
+								code: 40057
+							});
+						}
+						showToast('error', 'reconnecting_signaling_connection');
+						isSignalingError = true;
+					} else {
+						if (window.mereos.startRecordingCallBack) {
+							window.mereos.startRecordingCallBack({
+								type: 'success',
+								message: 'video_recording_reconnecting',
+								code: 50019
+							});
+						}
+						registerEvent({
+							notify: false,
+							eventName: 'video_recording_reconnecting',
+						});
+					}
+				};
+
+				const handleDisconnected = async () => {
+					cleanupLocalVideo();
+					registerEvent({
+						notify: false,
+						eventName: 'video_recording_disconnected',
+					});
+
+					updatePersistData('session', {
+						sessionStatus: 'Terminated'
+					});
+
+					if (findConfigs(['mobile_proctoring'], secureFeatures?.entities).length > 0) {
+						updatePersistData('preChecksSteps', {
+							mobileConnection: false,
+							screenSharing: false
+						});
+						showToast('error', 'mobile_phone_disconnected');
+						if (window.mereos.startRecordingCallBack) {
+							window.mereos.startRecordingCallBack({
+								type: 'error',
+								message: 'mobile_phone_disconnected_during_assessment',
+								code: 40058
+							});
+						}
+					} else {
+						updatePersistData('preChecksSteps', {
+							screenSharing: false,
+						});
+					}
+					if (window.mereos.startRecordingCallBack) {
+						window.mereos.startRecordingCallBack({
+							type: 'error',
+							message: 'web_internet_connection_disconnected',
+							code: 40014
+						});
+						window.mereos.recordingStart = false;
+					}
+					forceClosure();
+				};
+
+				const handleReconnected = async () => {
+					if (room.state === 'connected' && isMediaError) {
+						showToast('success', 'internet_connection_recovered');
+						isMediaError = false;
+					}
+					if (room.state === 'connected' && isSignalingError) {
+						showToast('success', 'signaling_connection_reconnected');
+						isSignalingError = false;
+					}
+					registerEvent({
+						notify: false,
+						eventName: 'video_recording_reconnected',
+					});
+					if (window.mereos.startRecordingCallBack) {
+						window.mereos.startRecordingCallBack({
+							type: 'success',
+							message: 'video_recording_reconnected',
+							code: 50020
+						});
+					}
+				};
+
+				room.on('reconnected', handleReconnected);
+				room.on('disconnected', handleDisconnected);
+				room.on('reconnecting', handleReconnecting);
+
+				registerEvent({
+					eventType: 'success',
+					notify: false,
+					eventName: 'recording_started_successfully',
+				});
+
+				// Primary success callback for start_session — LMS can start the exam here.
+				if (window.mereos.startRecordingCallBack) {
+					invokeStartSessionCallback({
+						type: 'success',
+						message: 'recording_started_successfully',
+						code: 50000
+					});
+				}
+
+			} catch (error) {
+				logger.error('error in startRecording', error);
+				await releaseAllMediaStreams();
+				updatePersistData('session', {
 					sessionStatus: 'Terminated'
 				});
-		
-				if(findConfigs(['mobile_proctoring'], secureFeatures?.entities).length > 0){
-					updatePersistData('preChecksSteps', { 
-						mobileConnection: false,
-						screenSharing: false
-					});
-					showToast('error','mobile_phone_disconnected');	
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
-							message: 'mobile_phone_disconnected_during_assessment',
-							code:40058
-						});
-					}	
-				}else{
-					updatePersistData('preChecksSteps', { 
-						screenSharing: false,
-					});
-				}
-				if(window.mereos.startRecordingCallBack){
-					window.mereos.startRecordingCallBack({ 
-						type:'error',
-						message: 'web_internet_connection_disconnected',
-						code:40014
-					});
-					window.mereos.recordingStart = false;
-				}
-				forceClosure();
-			};
-
-			const handleReconnected = async () => {
-				if (room.state === 'connected' && isMediaError) {
-					showToast('success','internet_connection_recovered');		
-					isMediaError = false;
-				}
-				if (room.state === 'connected' && isSignalingError) {
-					showToast('success','signaling_connection_reconnected');		
-					isSignalingError = false;
-				}
-				registerEvent({
-					notify: false,
-					eventName: 'video_recording_reconnected',
+				registerEvent({ eventType: 'success', notify: false, eventName: 'camera_or_microphone_permission_is_denied' });
+				sentryExceptioMessage(error, { type: 'error', message: 'Camera or microphone permission is denied' });
+				window.mereos.recordingStart = false;
+				const isPermissionError = error?.name === 'NotAllowedError' || error?.name === 'PermissionDeniedError';
+				invokeStartSessionCallback({
+					type: isPermissionError ? 'success' : 'error',
+					message: isPermissionError ? 'please_allow_camera_or_microphone_permission' : 'error_in_starting_the_session',
+					code: isPermissionError ? 50000 : 40004,
+					details: error,
 				});
-				if(window.mereos.startRecordingCallBack){
-					window.mereos.startRecordingCallBack({ 
-						type:'success',
-						message: 'video_recording_reconnected',
-						code:50020
-					});
-				}
-			};
-
-			room.on('reconnected', handleReconnected);
-			room.on('disconnected', handleDisconnected);
-			room.on('reconnecting',handleReconnecting);
-
-			registerEvent({ 
-				eventType: 'success', 
-				notify: false, 
-				eventName: 'recording_started_successfully', 
-			});
-			
-			if(window.mereos.startRecordingCallBack){
-				window.mereos.startRecordingCallBack({ 
-					type:'success',
-					message: 'recording_started_successfully',
-					code:50000
-				});
+				// Return so addSectionSessionRecord is not called after a failed recording start.
+				return;
 			}
-			
-		} catch (error) {
-			logger.error('error in startRecording',error);
-			await releaseAllMediaStreams();
+		} else {
+			// Lockdown-only profile (no Twilio recording entities).
 			updatePersistData('session', {
-				sessionStatus:'Terminated'
+				sessionStatus: 'Attending'
 			});
-			registerEvent({ eventType: 'success', notify: false, eventName: 'camera_or_microphone_permission_is_denied' });
-			sentryExceptioMessage(error,{type:'error',message:'Camera or microphone permission is denied'});
-			window.mereos.recordingStart = false;
-			if(window.mereos.startRecordingCallBack){
-				window.mereos.startRecordingCallBack({ 
-					type:'success',
-					message: 'please_allow_camera_or_microphone_permission',
-					code:50000
-				});
+			invokeStartSessionCallback({
+				type: 'success',
+				code: 50000,
+				message: 'recording_started_successfully'
+			});
+			window.mereos.recordingStart = true;
+		}
+		const updatedSession = convertDataIntoParse('session');
+		let resp = await addSectionSessionRecord(updatedSession, candidateInviteAssessmentSection);
+		if (resp) {
+			const dateTime = new Date();
+			if (!session?.browserEvents?.filter(item => item.name === 'session_started')?.length) {
+				registerEvent({ eventType: 'success', notify: false, eventName: 'session_started', startAt: dateTime });
 			}
 		}
-	}else{
-		updatePersistData('session', {
-			sessionStatus:'Attending'
+	} catch (error) {
+		// Catch-all for lockBrowser, fullscreen init, addSectionSessionRecord, etc.
+		logger.error('Unhandled error in startRecording:', error);
+		await releaseAllMediaStreams();
+		window.mereos.recordingStart = false;
+		sentryExceptioMessage(error, { type: 'error', message: 'Unhandled error in startRecording' });
+		invokeStartSessionCallback({
+			type: 'error',
+			message: 'error_in_starting_the_session',
+			code: 40004,
+			details: error,
 		});
-		if(window.mereos.startRecordingCallBack){
-			window.mereos.startRecordingCallBack({ 
-				type:'success',
-				code:50000,
-				message: 'recording_started_successfully' 
-			});
-		}
-		window.mereos.recordingStart = true;
-	}
-	const updatedSession = convertDataIntoParse('session');
-	let resp = await addSectionSessionRecord(updatedSession,candidateInviteAssessmentSection);
-	if(resp){
-		const dateTime = new Date();
-		if(!session?.browserEvents.filter(item => item.name === 'session_started')?.length){
-			registerEvent({ eventType: 'success', notify: false, eventName: 'session_started', startAt: dateTime });
-		}
 	}
 };
 
@@ -1045,19 +1119,19 @@ const setupWebcam = async (mediaStream) => {
 			if (!i18next.isInitialized) {
 				initializeI18next();
 			}
-            
+
 			let webcamContainer = window.mereos.shadowRoot.querySelector('#webcam-container');
 			if (!webcamContainer) {
 				webcamContainer = document.createElement('div');
 				webcamContainer.id = 'webcam-container';
 				webcamContainer.className = 'user-videos-remote';
-				if(findConfigs(['camera_view'], secureFeatures?.entities)?.length) {
+				if (findConfigs(['camera_view'], secureFeatures?.entities)?.length) {
 					window.mereos.shadowRoot.appendChild(webcamContainer);
 				}
 			}
-        
+
 			const candidateInviteAssessmentSection = convertDataIntoParse('candidateAssessment');
-            
+
 			let videoHeaderContainer = webcamContainer.querySelector('#user-video-header');
 			if (!videoHeaderContainer) {
 				videoHeaderContainer = document.createElement('div');
@@ -1083,16 +1157,16 @@ const setupWebcam = async (mediaStream) => {
 				videoHeaderContainer.appendChild(recordingIcon);
 				webcamContainer.appendChild(videoHeaderContainer);
 			}
-        
+
 			const remoteVideoRef = document.createElement('div');
 			remoteVideoRef.classList.add('remote-video');
 			remoteVideoRef.id = 'remote-video';
-			
+
 			// Initialize dimensions
 			let currentWidth = 200;
 			const MIN_WIDTH = 180;
 			const MAX_WIDTH = 600;
-			
+
 			let mediaWrapper = webcamContainer.querySelector('#user-video-element');
 			if (!mediaWrapper) {
 				mediaWrapper = document.createElement('div');
@@ -1112,7 +1186,7 @@ const setupWebcam = async (mediaStream) => {
 				mediaWrapper.innerHTML = '';
 				mediaWrapper.style.display = 'block';
 			}
-			
+
 			const videoElement = document.createElement('video');
 			videoElement.autoplay = true;
 			videoElement.muted = true;
@@ -1125,7 +1199,7 @@ const setupWebcam = async (mediaStream) => {
 				height: '100%',
 				objectFit: 'cover'
 			});
-        
+
 			const canvas = document.createElement('canvas');
 			canvas.id = 'canvas';
 			Object.assign(canvas.style, {
@@ -1135,14 +1209,14 @@ const setupWebcam = async (mediaStream) => {
 				width: '100%',
 				height: '100%'
 			});
-        
+
 			webcamContainer.appendChild(videoHeaderContainer);
 			mediaWrapper.appendChild(videoElement);
-			if(secureFeatures?.entities?.filter(entity => aiEventsFeatures.includes(entity.key))?.length) {
+			if (secureFeatures?.entities?.filter(entity => aiEventsFeatures.includes(entity.key))?.length) {
 				mediaWrapper.appendChild(canvas);
 			}
 			webcamContainer.appendChild(mediaWrapper);
-			
+
 			let videoFooterContainer = webcamContainer.querySelector('#user-video-footer');
 			if (!videoFooterContainer && findConfigs(['camera_view'], secureFeatures?.entities)?.length) {
 				videoFooterContainer = document.createElement('div');
@@ -1189,11 +1263,11 @@ const setupWebcam = async (mediaStream) => {
 						currentWidth = Math.min(currentWidth + 64, MAX_WIDTH);
 						const aspectRatio = 142 / 180;
 						const newHeight = Math.round(currentWidth * aspectRatio);
-						
+
 						webcamContainer.style.width = `${currentWidth}px`;
 						mediaWrapper.style.width = `${currentWidth}px`;
 						mediaWrapper.style.height = `${newHeight}px`;
-						
+
 						const remoteVideo = webcamContainer.querySelector('#remote-video');
 						if (remoteVideo) {
 							remoteVideo.style.width = `${currentWidth}px`;
@@ -1208,11 +1282,11 @@ const setupWebcam = async (mediaStream) => {
 						currentWidth = Math.max(currentWidth - 64, MIN_WIDTH);
 						const aspectRatio = 142 / 180;
 						const newHeight = Math.round(currentWidth * aspectRatio);
-						
+
 						webcamContainer.style.width = `${currentWidth}px`;
 						mediaWrapper.style.width = `${currentWidth}px`;
 						mediaWrapper.style.height = `${newHeight}px`;
-						
+
 						const remoteVideo = webcamContainer.querySelector('#remote-video');
 						if (remoteVideo) {
 							remoteVideo.style.width = `${currentWidth}px`;
@@ -1225,7 +1299,7 @@ const setupWebcam = async (mediaStream) => {
 				videoFooterContainer.appendChild(zoomInBtn);
 				webcamContainer.appendChild(videoFooterContainer);
 			}
-        
+
 			videoElement.addEventListener('loadedmetadata', () => {
 				canvas.width = videoElement.videoWidth;
 				canvas.height = videoElement.videoHeight;
@@ -1250,34 +1324,34 @@ const setupWebcam = async (mediaStream) => {
 				if (e.target.classList.contains('zoom-btns')) {
 					return;
 				}
-				
+
 				isDragging = true;
 				webcamContainer.style.cursor = 'grabbing';
-                
+
 				startX = e.clientX;
 				startY = e.clientY;
-                
+
 				const rect = webcamContainer.getBoundingClientRect();
 				initialX = rect.left;
 				initialY = rect.top;
-                
+
 				e.preventDefault();
 				e.stopPropagation();
 			};
 
 			const handleMouseMove = (e) => {
 				if (!isDragging) return;
-                
+
 				const dx = e.clientX - startX;
 				const dy = e.clientY - startY;
-                
+
 				const newX = initialX + dx;
 				const newY = initialY + dy;
-                
+
 				webcamContainer.style.left = `${newX}px`;
 				webcamContainer.style.top = `${newY}px`;
 				webcamContainer.style.right = 'auto';
-                
+
 				e.preventDefault();
 				e.stopPropagation();
 			};
@@ -1297,12 +1371,12 @@ const setupWebcam = async (mediaStream) => {
 				document.removeEventListener('mouseup', handleMouseUp);
 			};
 
-			resolve({ 
-				videoElement, 
+			resolve({
+				videoElement,
 				canvas,
 				cleanupDrag
 			});
-		} catch(e) {
+		} catch (e) {
 			reject(e);
 		}
 	});
@@ -1339,19 +1413,19 @@ const startAIWebcam = async (room, mediaStream) => {
 			await tf.setBackend('cpu');
 			await tf.ready();
 		}
-		
 
-		if(!window.mereos.net){
+
+		if (!window.mereos.net) {
 			window.mereos.net = await cocoSsd.load();
 		}
-    
+
 		const localParticipant = room.localParticipant;
 		const videoTrackPublications = Array.from(localParticipant.videoTracks.values());
-			
+
 		if (videoTrackPublications.length === 0) {
 			throw new Error('No video track available from local participant');
 		}
-		
+
 		const { canvas } = await setupWebcam(mediaStream, window.mereos.shadowRoot);
 		const context = canvas.getContext('2d');
 
@@ -1361,7 +1435,7 @@ const startAIWebcam = async (room, mediaStream) => {
 		processingVideo.autoplay = true;
 		processingVideo.playsInline = true;
 		window.mereos.aiProcessingVideo = processingVideo;
-			
+
 		await new Promise((resolve) => {
 			processingVideo.onloadedmetadata = () => {
 				processingVideo.width = processingVideo.videoWidth;
@@ -1396,7 +1470,7 @@ const startAIWebcam = async (room, mediaStream) => {
 
 				let log = {}, person = {}, multiplePersonFound = false;
 				let detectedObjects = new Set();
-			
+
 				predictions.forEach(prediction => {
 					if (prediction.class === 'person' && (personMissingFeature || multiplePeopleFeature)) {
 						if (person?.class && multiplePeopleFeature) {
@@ -1432,7 +1506,7 @@ const startAIWebcam = async (room, mediaStream) => {
 								...(key === 'object_detected' && detectedObjects.size > 0 ? { detected_objects: Array.from(detectedObjects) } : {})
 							};
 							aiEvents.push({ ...activeViolations[key], [key]: log[key] });
-						} 
+						}
 						else {
 							activeViolations[key].time_span += 1;
 							if (key === 'object_detected' && detectedObjects.size > 0) {
@@ -1452,82 +1526,82 @@ const startAIWebcam = async (room, mediaStream) => {
 								message = 'multiple_people_detected_for_more_than_10_seconds';
 							}
 							showToast('error', message);
-							if(window.mereos.startRecordingCallBack){
-								window.mereos.startRecordingCallBack({ 
-									type:'error',
+							if (window.mereos.startRecordingCallBack) {
+								window.mereos.startRecordingCallBack({
+									type: 'error',
 									message: message,
-									code:40059,
-									detail:activeViolations[key].time_span
+									code: 40059,
+									detail: activeViolations[key].time_span
 								});
-							}	
+							}
 						}
 					}
 					else if (activeViolations[key]) {
 						const violation = activeViolations[key];
 
 						if (violation.time_span >= 2) {
-							const data = { 
-								eventType: 'success', 
-								notify: true, 
-								eventName: key, 
-								eventValue:violation?.detected_objects?.length > 0 ? violation?.detected_objects[0]?.replace(/\s+/g, '_') : key,
-								startTime: violation.start_time, 
+							const data = {
+								eventType: 'success',
+								notify: true,
+								eventName: key,
+								eventValue: violation?.detected_objects?.length > 0 ? violation?.detected_objects[0]?.replace(/\s+/g, '_') : key,
+								startTime: violation.start_time,
 								endTime: violation.start_time + violation.time_span
 							};
 							registerAIEvent(data);
-							if(window.mereos.startRecordingCallBack){
-								window.mereos.startRecordingCallBack({ 
-									type:'error',
+							if (window.mereos.startRecordingCallBack) {
+								window.mereos.startRecordingCallBack({
+									type: 'error',
 									message: key,
-									code:40060,
-									detail:violation.start_time + violation.time_span
+									code: 40060,
+									detail: violation.start_time + violation.time_span
 								});
-							}	
+							}
 							checkForceClosureViolation();
 						}
-            
+
 						activeViolations[key] = null;
 					}
 				});
 			} catch (error) {
-				sentryExceptioMessage(error,{type:'error',message:'Error in AI processing'});
+				sentryExceptioMessage(error, { type: 'error', message: 'Error in AI processing' });
 				logger.error('Error in AI processing:', error);
 			}
 		}, 1000);
 
 		return { success: true, message: 'AI webcam started successfully' };
 	} catch (error) {
-		sentryExceptioMessage(error,{type:'error',message:'Failed to start AI webcam'});
+		sentryExceptioMessage(error, { type: 'error', message: 'Failed to start AI webcam' });
 		logger.error('Failed to start AI webcam:', error);
-		if(window.mereos.startRecordingCallBack){
-			window.mereos.startRecordingCallBack({ 
-				type:'error',
+		if (window.mereos.startRecordingCallBack) {
+			window.mereos.startRecordingCallBack({
+				type: 'error',
 				message: 'failed_to_start_ai_webcam',
-				code:40061,
+				code: 40061,
 			});
-		}	
+		}
 		if (window.mereos.aiProcessingInterval) {
 			clearInterval(window.mereos.aiProcessingInterval);
 		}
-    
-		return { 
-			success: false, 
+
+		return {
+			success: false,
 			message: 'Failed to start AI webcam',
-			error: error.message 
+			error: error.message
 		};
 	}
 };
 
 export const cleanupLocalVideo = () => {
-	if(window.mereos.shadowRoot){
+	if (window.mereos.shadowRoot) {
 		const webcamContainer = window.mereos.shadowRoot.querySelector('#webcam-container');
 		const webVideoContainer = window.mereos.shadowRoot.querySelector('#user-video-header');
 		const imgContainer = document.querySelector('#chat-icon-wrapper');
 
-		if(imgContainer){
+		if (imgContainer) {
 			imgContainer.remove();
 		}
-		if(webVideoContainer){
+		if (webVideoContainer) {
 			webVideoContainer.remove();
 		}
 
@@ -1554,20 +1628,20 @@ export const cleanupLocalVideo = () => {
 export function VideoChat(room) {
 	const secureFeatures = getSecureFeatures();
 	const session = convertDataIntoParse('session');
-    
+
 	let currentWidth = 200;
 	const aspectRatio = 142 / 180;
 	const initialHeight = Math.round(currentWidth * aspectRatio);
-    
+
 	let webcamContainer = window.mereos.shadowRoot.querySelector('#webcam-container');
 	let videoHeaderContainer = window.mereos.shadowRoot.querySelector('#user-video-header');
-    
+
 	if (!webcamContainer) {
 		webcamContainer = document.createElement('div');
 		webcamContainer.id = 'webcam-container';
 		webcamContainer.className = 'user-videos-remote';
 
-		if(findConfigs(['camera_view'], secureFeatures?.entities)?.length){
+		if (findConfigs(['camera_view'], secureFeatures?.entities)?.length) {
 			window.mereos.shadowRoot.appendChild(webcamContainer);
 		}
 
@@ -1590,34 +1664,34 @@ export function VideoChat(room) {
 			if (e.target.classList.contains('zoom-btns')) {
 				return;
 			}
-			
+
 			isDragging = true;
 			webcamContainer.style.cursor = 'grabbing';
-            
+
 			startX = e.clientX;
 			startY = e.clientY;
-            
+
 			const rect = webcamContainer.getBoundingClientRect();
 			initialX = rect.left;
 			initialY = rect.top;
-            
+
 			e.preventDefault();
 			e.stopPropagation();
 		};
 
 		const handleMouseMove = (e) => {
 			if (!isDragging) return;
-            
+
 			const dx = e.clientX - startX;
 			const dy = e.clientY - startY;
-            
+
 			const newX = initialX + dx;
 			const newY = initialY + dy;
-            
+
 			webcamContainer.style.left = `${newX}px`;
 			webcamContainer.style.top = `${newY}px`;
 			webcamContainer.style.right = 'auto';
-            
+
 			e.preventDefault();
 			e.stopPropagation();
 		};
@@ -1637,18 +1711,18 @@ export function VideoChat(room) {
 			document.removeEventListener('mouseup', handleMouseUp);
 		};
 	}
-    
-	if(!videoHeaderContainer){
+
+	if (!videoHeaderContainer) {
 		const candidateInviteAssessmentSection = convertDataIntoParse('candidateAssessment');
-    
+
 		videoHeaderContainer = document.createElement('div');
 		videoHeaderContainer.className = 'user-video-header';
 		videoHeaderContainer.id = 'user-video-header';
-    
+
 		const videoHeading = document.createElement('p');
 		videoHeading.className = 'recording-heading';
 		videoHeading.textContent = `${candidateInviteAssessmentSection?.candidate?.name}`;
-        
+
 		const recordingIcon = document.createElement('div');
 		recordingIcon.className = 'recording-badge-container-header';
 		recordingIcon.innerHTML = `
@@ -1659,12 +1733,12 @@ export function VideoChat(room) {
             ></img>
             <p class='recording-text'>${i18next.t('recording')}</p>
         `;
-    
+
 		videoHeaderContainer.appendChild(videoHeading);
 		videoHeaderContainer.appendChild(recordingIcon);
 		webcamContainer.appendChild(videoHeaderContainer);
 	}
-    
+
 	let userVideoElement = window.mereos.shadowRoot.querySelector('#user-video-element');
 	if (!userVideoElement) {
 		userVideoElement = document.createElement('div');
@@ -1680,7 +1754,7 @@ export function VideoChat(room) {
 		});
 		webcamContainer.appendChild(userVideoElement);
 	}
-    
+
 	const localVideoRef = document.createElement('div');
 	localVideoRef.classList.add('local-video');
 	localVideoRef.id = 'local-video';
@@ -1689,9 +1763,9 @@ export function VideoChat(room) {
 		height: '100%'
 	});
 	userVideoElement.appendChild(localVideoRef);
-    
+
 	let videoFooterContainer = window.mereos.shadowRoot.querySelector('#user-video-footer');
-	
+
 	const remoteVideoRef = document.createElement('div');
 	remoteVideoRef.classList.add('remote-video');
 	remoteVideoRef.id = 'remote-video';
@@ -1706,7 +1780,7 @@ export function VideoChat(room) {
 		transition: 'width 0.3s ease, height 0.3s ease',
 		background: '#000'
 	});
-	
+
 	if (videoFooterContainer) {
 		webcamContainer.insertBefore(remoteVideoRef, videoFooterContainer);
 	} else {
@@ -1719,9 +1793,9 @@ export function VideoChat(room) {
 				const attachedElement = track?.attach();
 				if (attachedElement) {
 					attachedElement.classList.add('video-attached');
-					
+
 					const isRemoteVideo = container.id === 'remote-video';
-					
+
 					if (isRemoteVideo) {
 						Object.assign(attachedElement.style, {
 							width: '100%',
@@ -1739,18 +1813,18 @@ export function VideoChat(room) {
 							objectFit: 'cover'
 						});
 					}
-					
+
 					container.appendChild(attachedElement);
 				}
 			} catch (error) {
-				sentryExceptioMessage(error,{type:'error',message:'Error attaching video track'});
-				if(window.mereos.startRecordingCallBack){
-					window.mereos.startRecordingCallBack({ 
-						type:'error',
+				sentryExceptioMessage(error, { type: 'error', message: 'Error attaching video track' });
+				if (window.mereos.startRecordingCallBack) {
+					window.mereos.startRecordingCallBack({
+						type: 'error',
 						message: 'error_attaching_video_track',
-						code:40062,
+						code: 40062,
 					});
-				}	
+				}
 				logger.error('Error attaching video track:', error);
 			}
 		} else {
@@ -1811,27 +1885,27 @@ export function VideoChat(room) {
 
 			room.on('participantReconnecting', async () => {
 				if (findConfigs(['mobile_proctoring'], secureFeatures?.entities).length > 0) {
-					updatePersistData('preChecksSteps', { 
+					updatePersistData('preChecksSteps', {
 						mobileConnection: false,
 						screenSharing: false
 					});
 					updatePersistData('session', {
-						sessionStatus:'Terminated'
+						sessionStatus: 'Terminated'
 					});
-					showToast('error',i18next.t('mobile_phone_disconnected'));
+					showToast('error', i18next.t('mobile_phone_disconnected'));
 				} else {
-					updatePersistData('preChecksSteps', { 
+					updatePersistData('preChecksSteps', {
 						screenSharing: false
-					});	
-					showToast('error',i18next.t('internet_connection_not_working'));					
+					});
+					showToast('error', i18next.t('internet_connection_not_working'));
 				}
 				await releaseAllMediaStreams();
 				setTimeout(() => {
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
-							code:40015,
-							message: 'mobile_internet_connection_disconnected' 
+					if (window.mereos.startRecordingCallBack) {
+						window.mereos.startRecordingCallBack({
+							type: 'error',
+							code: 40015,
+							message: 'mobile_internet_connection_disconnected'
 						});
 					}
 				}, 4000);
@@ -1850,14 +1924,14 @@ export function VideoChat(room) {
 			});
 		} catch (error) {
 			void releaseAllMediaStreams();
-			sentryExceptioMessage(error,{type:'error',message:'Error connecting to Twilio room'});
-			if(window.mereos.startRecordingCallBack){
-				window.mereos.startRecordingCallBack({ 
-					type:'error',
+			sentryExceptioMessage(error, { type: 'error', message: 'Error connecting to Twilio room' });
+			if (window.mereos.startRecordingCallBack) {
+				window.mereos.startRecordingCallBack({
+					type: 'error',
 					message: 'error_on_starting_recording',
-					code:40063,
+					code: 40063,
 				});
-			}	
+			}
 			logger.error('Error connecting to Twilio room:', error);
 		}
 	}
@@ -1886,9 +1960,9 @@ export const stopAllRecordings = async () => {
 		const secureFeatures = getSecureFeatures();
 		const session = convertDataIntoParse('session');
 
-		document.removeEventListener('visibilitychange', () => {});
-		document.removeEventListener('beforeunload', ()=> {});
-		window.removeEventListener('beforeunload',  ()=> {});
+		document.removeEventListener('visibilitychange', () => { });
+		document.removeEventListener('beforeunload', () => { });
+		window.removeEventListener('beforeunload', () => { });
 		window.removeEventListener('popstate', detectBackButtonCallback);
 		enableCopyPasteCut();
 		enableTextHighlighting();
@@ -1899,12 +1973,12 @@ export const stopAllRecordings = async () => {
 		if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
 			window.mereos.socket.send(JSON.stringify({ event: 'stopRecording', data: 'Web video recording stopped' }));
 		}
-		
+
 		const chatIcons = document.querySelectorAll('[id="chat-icon"]');
 		const chatContainer = document.getElementById('talkjs-container');
 		const notificationBagde = document.getElementById('notification-badge');
 
-		if(notificationBagde){
+		if (notificationBagde) {
 			notificationBagde.style.display = 'none';
 			notificationBagde.remove();
 		}
@@ -1923,7 +1997,7 @@ export const stopAllRecordings = async () => {
 
 		updatePersistData('session', {
 			recordingEnded: true,
-			sessionStatus: session?.sessionStatus === 'Terminated'? 'Terminated':'Completed',
+			sessionStatus: session?.sessionStatus === 'Terminated' ? 'Terminated' : 'Completed',
 		});
 
 		cleanupZendeskWidget();
@@ -1931,33 +2005,33 @@ export const stopAllRecordings = async () => {
 		removeStoppedListener();
 		window.mereos.recordingStart = false;
 
-		if (secureFeatures?.entities.filter(entity => recordingEvents.includes(entity.key))?.length > 0){
+		if (secureFeatures?.entities.filter(entity => recordingEvents.includes(entity.key))?.length > 0) {
 			registerEvent({ eventType: 'success', notify: false, eventName: 'recording_stopped_successfully' });
 		}
 
-		if (secureFeatures?.entities?.filter(entity => LockDownOptions.includes(entity.key))?.length){
+		if (secureFeatures?.entities?.filter(entity => LockDownOptions.includes(entity.key))?.length) {
 			unlockBrowserFromContent();
 		}
-		
+
 		await changeCandidateAssessmentStatus({
-			status: session?.sessionStatus === 'Terminated'? 'Terminated':'Completed',
+			status: session?.sessionStatus === 'Terminated' ? 'Terminated' : 'Completed',
 			id: session?.candidate_assessment
 		});
 
-		registerEvent({ eventType: 'success', notify: false, eventName: session?.sessionStatus === 'Terminated' ? 'session_is_terminated' : 'session_completed'});
-		
-		showToast(session?.sessionStatus === 'Terminated' ? 'error' :'success', session?.sessionStatus === 'Terminated' ? 'session_is_terminated' : 'session_completed');
-		
+		registerEvent({ eventType: 'success', notify: false, eventName: session?.sessionStatus === 'Terminated' ? 'session_is_terminated' : 'session_completed' });
+
+		showToast(session?.sessionStatus === 'Terminated' ? 'error' : 'success', session?.sessionStatus === 'Terminated' ? 'session_is_terminated' : 'session_completed');
+
 		return 'stop_recording';
 	} catch (e) {
-		if(window.mereos.startRecordingCallBack){
-			window.mereos.startRecordingCallBack({ 
-				type:'error',
+		if (window.mereos.startRecordingCallBack) {
+			window.mereos.startRecordingCallBack({
+				type: 'error',
 				message: 'error_on_stop_recording',
-				code:40064,
+				code: 40064,
 			});
-		}	
-		sentryExceptioMessage(e,{type:'error',message:'Error in stop recording'});
+		}
+		sentryExceptioMessage(e, { type: 'error', message: 'Error in stop recording' });
 		logger.error('Error in stop recording:', e);
 	} finally {
 		await releaseAllMediaStreams();

--- a/src/StartRecording/index.js
+++ b/src/StartRecording/index.js
@@ -1,8 +1,3 @@
-import * as TwilioVideo from 'twilio-video';
-import i18next from 'i18next';
-import { v4 } from 'uuid';
-import * as cocoSsd from '@tensorflow-models/coco-ssd';
-import * as tf from '@tensorflow/tfjs';
 import { 
 	addSectionSessionRecord, 
 	checkForceClosureViolation, 
@@ -27,6 +22,7 @@ import {
 	probeExactDevice, 
 	registerAIEvent, 
 	registerEvent, 
+	releaseAllMediaStreams,
 	restoreRightClick, 
 	sentryExceptioMessage, 
 	showToast, 
@@ -34,6 +30,11 @@ import {
 	updatePersistData, 
 	updateThemeColor
 } from '../utils/functions';
+import * as TwilioVideo from 'twilio-video';
+import i18next from 'i18next';
+import { v4 } from 'uuid';
+import * as cocoSsd from '@tensorflow-models/coco-ssd';
+import * as tf from '@tensorflow/tfjs';
 import { getCreateRoom } from '../services/twilio.services';
 import { aiEventsFeatures, ASSET_URL, LockDownOptions, recordingEvents } from '../utils/constant';
 import { changeCandidateAssessmentStatus } from '../services/candidate-assessment.services';
@@ -42,7 +43,6 @@ import { cleanupForceFullscreen, initializeForceFullscreen } from '../utils/full
 import { permissionModalStyle } from '../utils/styles';
 
 let aiEvents = [];
-let mediaStream = null;
 const trackStoppedListeners = new WeakMap();
 const deviceChangeHandlers = new WeakMap();
 let isMediaError = false;
@@ -587,6 +587,8 @@ const reconnectCamera = async () => {
 				});
 			}
 		}
+
+		await releaseAllMediaStreams();
         
 		if (typeof registerEvent === 'function') {
 			registerEvent({ 
@@ -695,6 +697,18 @@ export const startRecording = async () => {
 				false
 		};
 
+		[window.mereos.globalStream, window.mereos.audioStream].forEach((stream) => {
+			stream?.getTracks?.().forEach((track) => {
+				try {
+					track.stop();
+				} catch (error) {
+					logger.error('Failed to stop precheck media track:', error);
+				}
+			});
+		});
+		window.mereos.globalStream = null;
+		window.mereos.audioStream = null;
+
 		try {
 			const newRoomSessionId = v4();
 			const newSessionId = session?.sessionId ? session?.sessionId : v4();
@@ -709,6 +723,7 @@ export const startRecording = async () => {
 				room = await TwilioVideo.connect(session?.twilioToken, twilioOptions);
 				window.mereos.roomInstance = room;
 			}catch(error){
+				await releaseAllMediaStreams();
 				if (error.code) {
 					logger.error('Twilio error code:', error.code);
 				}
@@ -983,6 +998,7 @@ export const startRecording = async () => {
 			
 		} catch (error) {
 			logger.error('error in startRecording',error);
+			await releaseAllMediaStreams();
 			updatePersistData('session', {
 				sessionStatus:'Terminated'
 			});
@@ -1344,6 +1360,7 @@ const startAIWebcam = async (room, mediaStream) => {
 		processingVideo.srcObject = new MediaStream([videoTrackPublications[0].track.mediaStreamTrack]);
 		processingVideo.autoplay = true;
 		processingVideo.playsInline = true;
+		window.mereos.aiProcessingVideo = processingVideo;
 			
 		await new Promise((resolve) => {
 			processingVideo.onloadedmetadata = () => {
@@ -1518,7 +1535,9 @@ export const cleanupLocalVideo = () => {
 			const videoElement = webcamContainer.querySelector('video');
 			if (videoElement) {
 				videoElement.pause();
-				videoElement.srcObject.getTracks().forEach(track => track.stop());
+				if (videoElement.srcObject?.getTracks) {
+					videoElement.srcObject.getTracks().forEach(track => track.stop());
+				}
 				videoElement.srcObject = null;
 			}
 
@@ -1790,7 +1809,7 @@ export function VideoChat(room) {
 				handleParticipant(participant);
 			});
 
-			room.on('participantReconnecting', () => {
+			room.on('participantReconnecting', async () => {
 				if (findConfigs(['mobile_proctoring'], secureFeatures?.entities).length > 0) {
 					updatePersistData('preChecksSteps', { 
 						mobileConnection: false,
@@ -1806,6 +1825,7 @@ export function VideoChat(room) {
 					});	
 					showToast('error',i18next.t('internet_connection_not_working'));					
 				}
+				await releaseAllMediaStreams();
 				setTimeout(() => {
 					if(window.mereos.startRecordingCallBack){
 						window.mereos.startRecordingCallBack({ 
@@ -1829,6 +1849,7 @@ export function VideoChat(room) {
 				});
 			});
 		} catch (error) {
+			void releaseAllMediaStreams();
 			sentryExceptioMessage(error,{type:'error',message:'Error connecting to Twilio room'});
 			if(window.mereos.startRecordingCallBack){
 				window.mereos.startRecordingCallBack({ 
@@ -1853,6 +1874,14 @@ export function VideoChat(room) {
 }
 
 export const stopAllRecordings = async () => {
+	if (window.mereos.aiProcessingInterval) {
+		clearInterval(window.mereos.aiProcessingInterval);
+		window.mereos.aiProcessingInterval = null;
+	}
+
+	cleanupLocalVideo();
+	await releaseAllMediaStreams();
+
 	try {
 		const secureFeatures = getSecureFeatures();
 		const session = convertDataIntoParse('session');
@@ -1866,9 +1895,6 @@ export const stopAllRecordings = async () => {
 		restoreRightClick();
 		cleanupForceFullscreen();
 
-		if(window?.mereos?.mobileStream){
-			window?.mereos?.mobileStream?.getTracks()?.forEach((track) => track.stop());
-		}
 		window.mereos.forceClosureTriggered = false;
 		if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
 			window.mereos.socket.send(JSON.stringify({ event: 'stopRecording', data: 'Web video recording stopped' }));
@@ -1901,78 +1927,12 @@ export const stopAllRecordings = async () => {
 		});
 
 		cleanupZendeskWidget();
-		cleanupLocalVideo();
-
-		if(mediaStream){
-			mediaStream.getTracks().forEach(track => track.stop());
-			mediaStream=null;
-		}
-
-		if (window?.mereos?.newStream) {
-			window?.mereos?.newStream.getTracks().forEach(track => {
-				track.stop();
-				track.enabled = false;
-			});
-		}
-
-		if (window.mereos.globalStream) {
-			window.mereos.globalStream.getTracks().forEach(track => track.stop());
-			window.mereos.globalStream = null;
-		}
 
 		removeStoppedListener();
+		window.mereos.recordingStart = false;
 
-		window.mereos.recordingStart=false;
-
-		if (window?.mereos?.roomInstance) {
-			const tracks = window?.mereos?.roomInstance?.localParticipant?.tracks;
-			if (!tracks) return;
-    
-			for (const publication of tracks) {
-				const track = publication.track;
-				if (!track) continue;
-        
-				try {
-					await window.mereos.roomInstance.localParticipant.unpublishTrack(track);
-            
-					track.stop();
-					const elements = track.detach();
-					elements.forEach(element => element.remove());
-            
-					if (track.disable) track.disable();
-				} catch (error) {
-					logger.error('Failed to cleanup track:', error);
-				}
-			}
-
-			window.mereos.roomInstance.participants.forEach(participant => {
-				participant.removeAllListeners();
-			});
-			if (secureFeatures?.entities.filter(entity => recordingEvents.includes(entity.key))?.length > 0){
-				registerEvent({ eventType: 'success', notify: false, eventName: 'recording_stopped_successfully' });
-			}
-			window.mereos.roomInstance.removeAllListeners();
-			window.mereos.roomInstance.disconnect();
-			window.mereos.roomInstance = null;
-		}
-
-		if (window.mereos.mobileRoomInstance) {
-			window.mereos.mobileRoomInstance.localParticipant.tracks.forEach(publication => {
-				const track = publication.track;
-				if (track) {
-					track.stop();
-					track.detach().forEach(element => element.remove());
-					track.disable();
-					window.mereos.mobileRoomInstance.localParticipant.unpublishTrack(track);
-				}
-			});
-			window.mereos.mobileRoomInstance.disconnect();
-			window.mereos.mobileRoomInstance = null;
-		}
-
-		if (window.mereos.aiProcessingInterval) {
-			clearInterval(window.mereos.aiProcessingInterval);
-			window.mereos.aiProcessingInterval = null;
+		if (secureFeatures?.entities.filter(entity => recordingEvents.includes(entity.key))?.length > 0){
+			registerEvent({ eventType: 'success', notify: false, eventName: 'recording_stopped_successfully' });
 		}
 
 		if (secureFeatures?.entities?.filter(entity => LockDownOptions.includes(entity.key))?.length){
@@ -1999,5 +1959,7 @@ export const stopAllRecordings = async () => {
 		}	
 		sentryExceptioMessage(e,{type:'error',message:'Error in stop recording'});
 		logger.error('Error in stop recording:', e);
+	} finally {
+		await releaseAllMediaStreams();
 	}
 };

--- a/src/SystemRequirement/index.js
+++ b/src/SystemRequirement/index.js
@@ -1,15 +1,15 @@
 import i18next from 'i18next';
 
-import { 
-	getCPUInfo, 
-	getNetworkDownloadSpeed, 
-	getNetworkUploadSpeed, 
-	getRAMInfo, 
-	getSecureFeatures, 
-	logger, 
-	registerEvent, 
-	sentryExceptioMessage, 
-	updatePersistData 
+import {
+	getCPUInfo,
+	getNetworkDownloadSpeed,
+	getNetworkUploadSpeed,
+	getRAMInfo,
+	getSecureFeatures,
+	logger,
+	registerEvent,
+	sentryExceptioMessage,
+	updatePersistData
 } from '../utils/functions';
 import { ASSET_URL } from '../utils/constant';
 import { showTab } from '../ExamsPrechecks';
@@ -161,7 +161,7 @@ const handleDiagnosticItemClick = (id, checkFunction) => {
 	if (!element) {
 		return;
 	}
-	
+
 	// Check if element already has success status
 	const statusIcon = window.mereos.shadowRoot.getElementById(`${id}StatusIcon`);
 	if (statusIcon && statusIcon.src.includes(successIconMap[id].split('/').pop())) {
@@ -180,12 +180,12 @@ const handleDiagnosticItemClick = (id, checkFunction) => {
 		if (!statusIcon || !statusLoading) {
 			return;
 		}
-		
+
 		// Check if already in success state
 		if (statusIcon.src.includes(successIconMap[id].split('/').pop())) {
 			return;
 		}
-		
+
 		continueButton.disabled = true;
 		if (refreshButton) {
 			refreshButton.disabled = true;
@@ -194,42 +194,52 @@ const handleDiagnosticItemClick = (id, checkFunction) => {
 		statusLoading.src = `${ASSET_URL}/loading-gray.svg`;
 		statusIcon.src = `${ASSET_URL}/${statusIconMap[id]}`;
 
-		const resp = await checkFunction();
+		try {
+			const resp = await checkFunction();
 
-		const ram_info = (parseInt(resp?.capacity) / (1024 ** 3)).toFixed(0);
-		const isGoodRam = Number(ram_info) >= profileSettings?.ram_size;
+			const ram_info = (parseInt(resp?.capacity) / (1024 ** 3)).toFixed(0);
+			const isGoodRam = Number(ram_info) >= profileSettings?.ram_size;
 
-		const isGoodCpu = Number(resp?.noOfPrcessor) >= profileSettings?.cpu_size;
+			const isGoodCpu = Number(resp?.noOfPrcessor) >= profileSettings?.cpu_size;
 
-		const isGoodUpload = Number(resp?.speedMbps) >= profileSettings?.upload_speed;
-		const isGoodDownload = Number(resp?.speedMbps) >= profileSettings?.download_speed;
+			const isGoodUpload = Number(resp?.speedMbps) >= profileSettings?.upload_speed;
+			const isGoodDownload = Number(resp?.speedMbps) >= profileSettings?.download_speed;
 
-		let finalResult;
-		switch (id) {
-			case 'ram':
-				finalResult = isGoodRam;
-				break;
-			case 'cpu':
-				finalResult = isGoodCpu;
-				break;
-			case 'upload_speed':
-				finalResult = isGoodUpload;
-				break;
-			case 'download_speed':
-				finalResult = isGoodDownload;
-				break;
-			default:
-				finalResult = resp;
+			let finalResult;
+			switch (id) {
+				case 'ram':
+					finalResult = isGoodRam;
+					break;
+				case 'cpu':
+					finalResult = isGoodCpu;
+					break;
+				case 'upload_speed':
+					finalResult = isGoodUpload;
+					break;
+				case 'download_speed':
+					finalResult = isGoodDownload;
+					break;
+				default:
+					finalResult = resp;
+			}
+
+			setElementStatus(id, { success: successIconMap[id], failure: failureIconMap[id] }, finalResult);
+		} catch (error) {
+			logger.error(`Error checking ${id} requirement:`, error);
+			sentryExceptioMessage(error, { type: 'error', message: `Error checking ${id} requirement` });
+			setElementStatus(id, { success: successIconMap[id], failure: failureIconMap[id] }, false);
+			if (id === 'download_speed') {
+				registerEvent({ notify: false, eventName: 'download_speed_insufficient', eventValue: 'speed_test_failed' });
+			}
 		}
 
-		setElementStatus(id, { success: successIconMap[id], failure: failureIconMap[id] }, finalResult);
 		updateContinueButtonState();
 		updateRefreshButtonVisibility();
 		if (refreshButton) refreshButton.disabled = false;
 	};
 
 	element.addEventListener('click', clickHandler);
-	
+
 	// Store reference to the handler for removal
 	element._clickHandler = clickHandler;
 };
@@ -237,50 +247,50 @@ const handleDiagnosticItemClick = (id, checkFunction) => {
 const retryAllFailedRequirements = async () => {
 	const refreshBtn = window.mereos.shadowRoot.getElementById('requirementRefreshBtn');
 	const continueBtn = window.mereos.shadowRoot.getElementById('requirementContinueBtn');
-	
+
 	if (refreshBtn && continueBtn) {
 		refreshBtn.disabled = true;
 		refreshBtn.style.display = 'none'; // Hide refresh button during batch retry processing
 		continueBtn.disabled = true;
-		
+
 		const originalText = refreshBtn.textContent;
 		refreshBtn.textContent = i18next.t('retrying');
-		
+
 		try {
 			const candidateAssessment = await getSecureFeatures();
 			const secureFeatures = candidateAssessment?.entities || [];
 			const profileSettings = candidateAssessment?.settings;
-			
+
 			const failedRequirements = getFailedRequirements();
-			
+
 			const retryPromises = [];
-			
+
 			if (failedRequirements.includes('ram') && secureFeatures.find(entity => entity.key === 'verify_ram')) {
 				retryPromises.push(retryRequirementItem('ram', getRAMInfo, profileSettings));
 			}
-			
+
 			if (failedRequirements.includes('cpu') && secureFeatures.find(entity => entity.key === 'verify_cpu')) {
 				retryPromises.push(retryRequirementItem('cpu', getCPUInfo, profileSettings));
 			}
-			
+
 			if (failedRequirements.includes('upload_speed') && secureFeatures.find(entity => entity.key === 'verify_upload_speed')) {
 				retryPromises.push(retryRequirementItem('upload_speed', getNetworkUploadSpeed, profileSettings));
 			}
-			
+
 			if (failedRequirements.includes('download_speed') && secureFeatures.find(entity => entity.key === 'verify_download_speed')) {
 				retryPromises.push(retryRequirementItem('download_speed', getNetworkDownloadSpeed, profileSettings));
 			}
-			
+
 			await Promise.all(retryPromises);
-			
-			registerEvent({ 
-				eventType: 'info', 
-				notify: false, 
-				eventName: 'requirements_retry_attempted' 
+
+			registerEvent({
+				eventType: 'info',
+				notify: false,
+				eventName: 'requirements_retry_attempted'
 			});
-			
+
 		} catch (error) {
-			sentryExceptioMessage(error,{type:'error',message:`Error retrying requirements`});
+			sentryExceptioMessage(error, { type: 'error', message: `Error retrying requirements` });
 			logger.error('Error retrying requirements:', error);
 		} finally {
 			refreshBtn.textContent = originalText;
@@ -294,18 +304,18 @@ const retryAllFailedRequirements = async () => {
 const retryRequirementItem = async (id, checkFunction, profileSettings) => {
 	const statusIcon = window.mereos.shadowRoot.getElementById(`${id}StatusIcon`);
 	const statusLoading = window.mereos.shadowRoot.getElementById(`${id}StatusLoading`);
-	
+
 	if (!statusIcon || !statusLoading) {
 		return false;
 	}
-	
+
 	statusIcon.src = `${ASSET_URL}/${statusIconMap[id]}`;
 	statusLoading.src = `${ASSET_URL}/loading-gray.svg`;
-	
+
 	try {
 		const resp = await checkFunction();
 		const ram_info = (parseInt(resp?.capacity) / (1024 ** 3)).toFixed(0);
-		
+
 		let finalResult;
 		switch (id) {
 			case 'ram':
@@ -323,42 +333,42 @@ const retryRequirementItem = async (id, checkFunction, profileSettings) => {
 			default:
 				finalResult = false;
 		}
-		
+
 		setElementStatus(id, { success: successIconMap[id], failure: failureIconMap[id] }, finalResult);
-		
+
 		if (finalResult) {
-			if(window.mereos.globalCallback) {
-				window.mereos.globalCallback({ 
-					type:'success',
-					message: `system_requirement_retry_success` ,
-					code:50011
+			if (window.mereos.globalCallback) {
+				window.mereos.globalCallback({
+					type: 'success',
+					message: `system_requirement_retry_success`,
+					code: 50011
 				});
 			}
-			registerEvent({ 
-				eventType: 'success', 
-				notify: false, 
-				eventName: `${id}_requirement_retry_success` 
+			registerEvent({
+				eventType: 'success',
+				notify: false,
+				eventName: `${id}_requirement_retry_success`
 			});
 		} else {
-			if(window.mereos.globalCallback) {
-				window.mereos.globalCallback({ 
-					type:'error',
-					message: `system_requirement_retry_failed` ,
-					code:40041
+			if (window.mereos.globalCallback) {
+				window.mereos.globalCallback({
+					type: 'error',
+					message: `system_requirement_retry_failed`,
+					code: 40041
 				});
 			}
-			registerEvent({ 
-				eventType: 'error', 
-				notify: false, 
-				eventName: `${id}_requirement_retry_failed` 
+			registerEvent({
+				eventType: 'error',
+				notify: false,
+				eventName: `${id}_requirement_retry_failed`
 			});
 		}
-		
+
 		return finalResult;
 	} catch (error) {
 		logger.error(`Error retrying ${id} requirement:`, error);
 		setElementStatus(id, { success: successIconMap[id], failure: failureIconMap[id] }, false);
-		sentryExceptioMessage(error,{type:'error',message:`Error retrying ${id} requirement:`});
+		sentryExceptioMessage(error, { type: 'error', message: `Error retrying ${id} requirement:` });
 		return false;
 	}
 };
@@ -366,19 +376,19 @@ const retryRequirementItem = async (id, checkFunction, profileSettings) => {
 const getFailedRequirements = () => {
 	const failedItems = [];
 	const requirementItems = ['ram', 'cpu', 'upload_speed', 'download_speed'];
-	
+
 	requirementItems.forEach(itemId => {
 		const statusIcon = window.mereos.shadowRoot.getElementById(`${itemId}StatusIcon`);
 		if (!statusIcon) return;
-		
+
 		const currentIconPathname = new URL(statusIcon.src).pathname;
 		const failureIconPathname = new URL(failureIconMap[itemId] || '').pathname;
-		
+
 		if (currentIconPathname === failureIconPathname) {
 			failedItems.push(itemId);
 		}
 	});
-	
+
 	return failedItems;
 };
 
@@ -405,11 +415,11 @@ const updateContinueButtonState = () => {
 const updateRefreshButtonVisibility = () => {
 	const refreshBtn = window.mereos.shadowRoot.getElementById('requirementRefreshBtn');
 	const continueBtn = window.mereos.shadowRoot.getElementById('requirementContinueBtn');
-	
+
 	if (!refreshBtn || !continueBtn) return;
-	
+
 	const failedRequirements = getFailedRequirements();
-	
+
 	if (failedRequirements.length > 0) {
 		refreshBtn.style.display = 'block';
 		continueBtn.style.display = 'none';
@@ -462,24 +472,50 @@ export const SystemRequirement = async (tab1Content) => {
 		}
 
 		if (verifyUploadSpeed) {
-			promises.push(getNetworkUploadSpeed().then(network => {
-				updatePersistData('session', { uploadSpeed: network });
-				const isGoodUpload = Number(network.speedMbps) >= profileSettings?.upload_speed;
-				setElementStatus('upload_speed', { success: uploadSpeedGreen, failure: uploadSpeedRed }, isGoodUpload);
-				return isGoodUpload;
-			}));
+			console.log('[mereos] Running upload speed check, minimum Mbps:', profileSettings?.upload_speed);
+			promises.push(
+				getNetworkUploadSpeed()
+					.then(network => {
+						console.log('[mereos] Upload speed result:', network, 'minimum:', profileSettings?.upload_speed);
+						updatePersistData('session', { uploadSpeed: network });
+						const isGoodUpload = Number(network?.speedMbps) >= profileSettings?.upload_speed;
+						setElementStatus('upload_speed', { success: uploadSpeedGreen, failure: uploadSpeedRed }, isGoodUpload);
+						return isGoodUpload;
+					})
+					.catch(error => {
+						console.error('[mereos] Upload speed check failed:', error);
+						logger.error('Error checking upload speed:', error);
+						setElementStatus('upload_speed', { success: uploadSpeedGreen, failure: uploadSpeedRed }, false);
+						return false;
+					}),
+			);
 		} else {
+			console.log('[mereos] Upload speed check skipped (not enabled in profile)');
 			setElementStatus('upload_speed', { success: uploadSpeedGreen, failure: uploadSpeedRed }, true);
 		}
 
 		if (verifyDownloadSpeed) {
-			promises.push(getNetworkDownloadSpeed().then(network => {
-				updatePersistData('session', { downloadSpeed: network });
-				const isGoodDownload = Number(network.speedMbps) >= profileSettings?.download_speed;
-				setElementStatus('download_speed', { success: downloadSpeedGreen, failure: downloadSpeedRed }, isGoodDownload);
-				return isGoodDownload;
-			}));
+			console.log('[mereos] Running download speed check, minimum Mbps:', profileSettings?.download_speed);
+			promises.push(
+				getNetworkDownloadSpeed()
+					.then(network => {
+						console.log('[mereos] Download speed result:', network, 'minimum:', profileSettings?.download_speed);
+						updatePersistData('session', { downloadSpeed: network });
+						const isGoodDownload = Number(network.speedMbps) >= profileSettings?.download_speed;
+						setElementStatus('download_speed', { success: downloadSpeedGreen, failure: downloadSpeedRed }, isGoodDownload);
+						return isGoodDownload;
+					})
+					.catch(error => {
+						console.error('[mereos] Download speed check failed:', error);
+						logger.error('Error checking download speed:', error);
+						sentryExceptioMessage(error, { type: 'error', message: 'Error checking download speed' });
+						setElementStatus('download_speed', { success: downloadSpeedGreen, failure: downloadSpeedRed }, false);
+						registerEvent({ notify: false, eventName: 'download_speed_insufficient', eventValue: 'speed_test_failed' });
+						return false;
+					}),
+			);
 		} else {
+			console.log('[mereos] Download speed check skipped (not enabled in profile)');
 			setElementStatus('download_speed', { success: downloadSpeedGreen, failure: downloadSpeedRed }, true);
 		}
 
@@ -489,7 +525,7 @@ export const SystemRequirement = async (tab1Content) => {
 		updateRefreshButtonVisibility();
 
 	} catch (error) {
-		sentryExceptioMessage(error,{type:'error',message:`Error running system requirement`});
+		sentryExceptioMessage(error, { type: 'error', message: `Error running system requirement` });
 		logger.error('Error running system requirement:', error);
 	}
 };
@@ -518,7 +554,7 @@ const updateDiagnosticText = () => {
 	if (btnText) {
 		btnText.textContent = i18next.t('continue');
 	}
-	
+
 	const refreshBtn = window.mereos.shadowRoot.getElementById('requirementRefreshBtn');
 	if (refreshBtn) {
 		refreshBtn.textContent = i18next.t('refresh');

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -2732,13 +2732,22 @@ export const detectBrowserActions = async () => {
 		localStorage.removeItem('examLeaveTime');
 	}
 
-	window.mereos.startRecordingCallBack({
-		type: 'error',
-		message: navType === 'navigate' ? 'candidate_came_back_to_assessment_page' : navType === 'back_forward' ? 'candidate_move_back_or_forward_from_the_page' : 'candidate_refreshed_the_assessment_page',
-		code: 40019
-	});
+	/*
+	 * Only notify LMS on real return to an in-progress exam (reload/back/leave), not on
+	 * first page load where navType is typically "navigate" without examLeaveTime.
+	 */
+	const isActiveSession = session?.quizStartTime > 1 && session?.sessionStatus === 'Attending';
+	const isNavigationReturn = navType === 'reload' || navType === 'back_forward' || (navType === 'navigate' && leaveTime);
 
-	if (session?.quizStartTime > 1 && session?.sessionStatus === 'Attending') {
+	if (isActiveSession && isNavigationReturn && typeof window.mereos?.startRecordingCallBack === 'function') {
+		window.mereos.startRecordingCallBack({
+			type: 'error',
+			message: navType === 'navigate' ? 'candidate_came_back_to_assessment_page' : navType === 'back_forward' ? 'candidate_move_back_or_forward_from_the_page' : 'candidate_refreshed_the_assessment_page',
+			code: 40019
+		});
+	}
+
+	if (isActiveSession && isNavigationReturn) {
 		registerEvent({
 			eventType: 'error',
 			notify: false,

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -1,15 +1,15 @@
-import { 
-	BROWSER_SECURTIY_STEP, 
-	examPreparationSteps, 
-	preChecksSteps, 
-	SYSTEM_REQUIREMENT_STEP, 
-	systemDiagnosticSteps
+import {
+	BROWSER_SECURTIY_STEP,
+	examPreparationSteps,
+	preChecksSteps,
+	SYSTEM_REQUIREMENT_STEP,
+	systemDiagnosticSteps,
+	BASE_URL
 } from './constant';
 import { addSectionSession, editSectionSession } from '../services/sessions.service';
 import { getRecordingSid } from '../services/twilio.services';
 import { bulkRegisterAIEvents, createAiEvent } from '../services/ai-event.services';
 import { bulkRegisterEvents, createEvent } from '../services/event.service';
-import { testUploadSpeed } from '../services/general.services';
 import i18next from 'i18next';
 import { closeModal, openModal } from '../ExamsPrechecks';
 import { Notyf } from 'notyf';
@@ -22,7 +22,7 @@ import * as Sentry from '@sentry/browser';
 export function sentryExceptioMessage(error, extra = {}) {
 	Sentry?.captureException(error, {
 		extra: extra
-	});					
+	});
 }
 
 export const logger = {
@@ -39,7 +39,7 @@ export const logger = {
 };
 
 export const dataURIToBlob = (dataURI) => {
-	
+
 	const splitDataURI = dataURI.split(',');
 	if (splitDataURI.length < 2) {
 		return null;
@@ -66,9 +66,9 @@ export const forceClosure = async () => {
 				const isOnline = navigator.onLine;
 				const updatedSession = convertDataIntoParse('session');
 
-				document.removeEventListener('visibilitychange', () => {});
-				document.removeEventListener('beforeunload', ()=> {});
-				window.removeEventListener('beforeunload',  ()=> {});
+				document.removeEventListener('visibilitychange', () => { });
+				document.removeEventListener('beforeunload', () => { });
+				window.removeEventListener('beforeunload', () => { });
 
 				if (!isOnline) {
 					if (window.mereos.socket && window.mereos.socket.readyState === WebSocket.OPEN) {
@@ -76,14 +76,14 @@ export const forceClosure = async () => {
 					}
 					showToast('error', 'signaling_connection_disconnected');
 					addSectionSessionRecord(updatedSession, candidateInviteAssessmentSection);
-					registerEvent({ 
-						eventType: 'success', 
-						notify: false, 
-						eventName: 'signaling_connection_disconnected', 
-						eventValue: getDateTime() 
+					registerEvent({
+						eventType: 'success',
+						notify: false,
+						eventName: 'signaling_connection_disconnected',
+						eventValue: getDateTime()
 					});
-					window.mereos.startRecordingCallBack({ 
-						type: 'error', 
+					window.mereos.startRecordingCallBack({
+						type: 'error',
 						message: 'signaling_connection_disconnected',
 						code: 40006
 					});
@@ -95,25 +95,25 @@ export const forceClosure = async () => {
 					}
 
 					await addSectionSessionRecord(updatedSession, candidateInviteAssessmentSection);
-						
-					await registerEvent({ 
-						eventType: 'error', 
-						notify: false, 
-						eventName: 'assessment_closed_due_to_multiple_violation', 
+
+					await registerEvent({
+						eventType: 'error',
+						notify: false,
+						eventName: 'assessment_closed_due_to_multiple_violation',
 						eventValue: getDateTime(),
 					});
 
 					resetSessionData();
 
-					window.mereos.startRecordingCallBack({ 
-						type: 'error', 
+					window.mereos.startRecordingCallBack({
+						type: 'error',
 						message: 'assessment_closed_due_to_multiple_violation',
 						code: 400010
 					});
 				}
 
 			} catch (apiError) {
-				sentryExceptioMessage(apiError,{type:'error',message:`API error during force closure`});
+				sentryExceptioMessage(apiError, { type: 'error', message: `API error during force closure` });
 				logger.error('API error during force closure:', apiError);
 				resetSessionData();
 			}
@@ -121,15 +121,15 @@ export const forceClosure = async () => {
 			window.mereos.roomInstance = null;
 			window.mereos.recordingStart = false;
 			if (window.mereos.startRecordingCallBack) {
-				window.mereos.startRecordingCallBack({ 
-					type: 'error', 
+				window.mereos.startRecordingCallBack({
+					type: 'error',
 					message: 'signaling_connection_disconnected',
 					code: 40006
 				});
 			}
 		}
 	} catch (error) {
-		sentryExceptioMessage(error,{type:'error',message:`Error in forceClosure`});
+		sentryExceptioMessage(error, { type: 'error', message: `Error in forceClosure` });
 		logger.error('Error in forceClosure:', error);
 		resetSessionData();
 	}
@@ -142,11 +142,11 @@ export const resetSessionData = () => {
 	}
 
 	localStorage.clear();
-	
+
 	window.mereos.forceClosureTriggered = false;
 
 	if (window.mereos.startRecordingCallBack) {
-		window.mereos.startRecordingCallBack({ 
+		window.mereos.startRecordingCallBack({
 			type: 'error',
 			message: 'internet_connection_lost_force_close_your_session',
 			code: 40007
@@ -155,7 +155,7 @@ export const resetSessionData = () => {
 };
 
 export const forceClosureIncident = (
-	browserEvents = [], 
+	browserEvents = [],
 	profile
 ) => {
 	const browserIncidentlevel = findBrowserIncidentLevel(browserEvents, profile);
@@ -186,7 +186,7 @@ export const findIncidentLevel = (aiEvents = [], browserEvents = [], profile) =>
 
 export const findAIIncidentLevel = (aiEvents = [], settingLevel) => {
 	let totalPoints = 0;
-    
+
 	for (const item of aiEvents) {
 		const duration = item.end_at - item.start_at;
 		let points = 0;
@@ -238,7 +238,7 @@ export const findAIIncidentLevel = (aiEvents = [], settingLevel) => {
 					break;
 			}
 		}
-        
+
 		// LENIENT setting (default)
 		else {
 			switch (item.name) {
@@ -282,7 +282,7 @@ export const findAIIncidentLevel = (aiEvents = [], settingLevel) => {
 	}
 
 	console.log('Total AI Points:', totalPoints);
-    
+
 	if (totalPoints >= 50) {
 		return 'high';
 	} else if (totalPoints >= 24) {
@@ -294,9 +294,9 @@ export const findAIIncidentLevel = (aiEvents = [], settingLevel) => {
 
 export const findBrowserIncidentLevel = (browserEvents = [], settingLevel) => {
 	let totalPoints = 0;
-	console.log('browserEvents',browserEvents);
+	console.log('browserEvents', browserEvents);
 	let copyPasteCutEvents = browserEvents.filter(item =>
-		['candidate_paste_the_content', 'candidate_copy_the_content', 'copy_and_paste','candidate_cut_the_content'].includes(item.name)
+		['candidate_paste_the_content', 'candidate_copy_the_content', 'copy_and_paste', 'candidate_cut_the_content'].includes(item.name)
 	);
 	let browserResizedEvents = browserEvents.filter(item => item.name === 'candidate_resized_window');
 	const awayEvents = browserEvents.filter(item => item.name === 'moved_back_to_page');
@@ -306,12 +306,12 @@ export const findBrowserIncidentLevel = (browserEvents = [], settingLevel) => {
 
 	let copyPastePoints = 10;
 	let resizePoints = 10;
-	
+
 	if (settingLevel === 'strict') {
 		copyPastePoints = 50;
 		resizePoints = 50;
 	}
-	
+
 	navigatingAway.forEach(() => {
 		totalPoints += 50;
 	});
@@ -370,7 +370,7 @@ export const findBrowserIncidentLevel = (browserEvents = [], settingLevel) => {
 	}
 };
 
-export const checkForceClosureViolation = async () =>{
+export const checkForceClosureViolation = async () => {
 	const session = convertDataIntoParse('session');
 	if (!session || !session.browserEvents) {
 		return;
@@ -381,12 +381,12 @@ export const checkForceClosureViolation = async () =>{
 	const candidateInviteAssessmentSection = convertDataIntoParse('candidateAssessment');
 	let incidentLevel = findIncidentLevel(
 		aiEvents,
-		browserEvents, 
+		browserEvents,
 		secureFeatures
 	);
 
-	if((incidentLevel === 'high' || incidentLevel === 'medium') && incident_level !== 'high'){
-		await addSectionSessionRecord(session,candidateInviteAssessmentSection);
+	if ((incidentLevel === 'high' || incidentLevel === 'medium') && incident_level !== 'high') {
+		await addSectionSessionRecord(session, candidateInviteAssessmentSection);
 		updatePersistData('session', { incident_level: incidentLevel });
 	}
 	if (
@@ -418,7 +418,7 @@ export const checkCamera = () => {
 					resolve(stream);
 				})
 				.catch((e) => {
-					logger.error('erre',e);
+					logger.error('erre', e);
 					resolve(false);
 				});
 		} else if (navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia || navigator.msGetUserMedia) {
@@ -439,8 +439,8 @@ export const getLocation = () => {
 		let startPos;
 		const geoSuccess = (position) => {
 			startPos = position;
-			const {latitude, longitude} = startPos.coords;
-			resolve({latitude, longitude});
+			const { latitude, longitude } = startPos.coords;
+			resolve({ latitude, longitude });
 		};
 		const geoError = (_error) => {
 			resolve(false);
@@ -465,7 +465,7 @@ export const getMultipleCameraDevices = () => {
 							label.includes('isight')
 						);
 					};
-				
+
 					if (isDefaultCamera(a)) {
 						return -1;
 					} else if (isDefaultCamera(b)) {
@@ -485,7 +485,7 @@ export const getMultipleCameraDevices = () => {
 export const detectMultipleScreens = async () => {
 	if (window.screen.isExtended) {
 		return true;
-	}else {
+	} else {
 		return false;
 	}
 };
@@ -523,8 +523,8 @@ export async function registerEvent({ eventName, eventValue = null, duration }) 
 			retryFailedEvents();
 		}
 
-		const startTime = session?.quizStartTime !== 0 
-			? Math.round((getTimeInSeconds({ isUTC: true }) - session?.quizStartTime) / 1000) 
+		const startTime = session?.quizStartTime !== 0
+			? Math.round((getTimeInSeconds({ isUTC: true }) - session?.quizStartTime) / 1000)
 			: 0;
 
 		if (session?.id) {
@@ -544,14 +544,14 @@ export async function registerEvent({ eventName, eventValue = null, duration }) 
 			try {
 				await createEvent(event);
 			} catch (err) {
-				sentryExceptioMessage(err,{type:'error',message:`API failed, storing event for retry`});
+				sentryExceptioMessage(err, { type: 'error', message: `API failed, storing event for retry` });
 				logger.error('API failed, storing event for retry', err);
 				const failedEvents = JSON.parse(localStorage.getItem('failedEvents') || '[]');
 				localStorage.setItem('failedEvents', JSON.stringify([...failedEvents, event]));
 			}
 		}
 	} catch (error) {
-		sentryExceptioMessage(error,{type:'error',message:`Error in registerEvent`});
+		sentryExceptioMessage(error, { type: 'error', message: `Error in registerEvent` });
 		logger.error('Error in registerEvent', error);
 	}
 }
@@ -628,7 +628,7 @@ export const loadZendeskWidget = () => {
 	const getSecureFeature = getSecureFeatures();
 	const secureFeatures = getSecureFeature?.entities || [];
 	const hasChatBot = secureFeatures?.some(entity => entity.key === 'chat_bot');
-	
+
 	if (hasChatBot) {
 		if (!document.querySelector('#ze-snippet')) {
 			const script = document.createElement('script');
@@ -638,16 +638,16 @@ export const loadZendeskWidget = () => {
 
 			document.body.appendChild(script);
 		}
-		
+
 		if (window.zE && typeof window.zE === 'function') {
 			window.zE('messenger', 'show');
-			
+
 			window.zE('messenger:on', 'open', () => {
 				setTimeout(() => {
 					const allZendeskElements = document.querySelectorAll('iframe[id*="webWidget"], iframe[title*="Chat"], iframe[title*="Help"], iframe[title*="Zendesk"], div[data-testid*="widget"], div[data-testid*="chat"], div[data-testid*="messenger"], [id*="zendesk"], [class*="zendesk"], [class*="zEWidget"]');
 					allZendeskElements.forEach(element => {
 						element.style.setProperty('z-index', '2147483647', 'important');
-						
+
 						let parent = element.parentElement;
 						while (parent && parent !== document.body) {
 							parent.style.setProperty('z-index', '2147483647', 'important');
@@ -656,7 +656,7 @@ export const loadZendeskWidget = () => {
 					});
 				}, 100);
 			});
-			
+
 			window.zE('messenger:on', 'close', () => {
 				setTimeout(() => {
 					const launcher = document.querySelector('#launcher');
@@ -669,7 +669,7 @@ export const loadZendeskWidget = () => {
 	}
 };
 
-export const hideZendeskWidget =() => {
+export const hideZendeskWidget = () => {
 	if (window.zE && typeof window.zE === 'function') {
 		try {
 			window.zE('messenger', 'hide');
@@ -694,7 +694,7 @@ export const cleanupZendeskWidget = () => {
 			delete window.zE;
 			delete window.zESettings;
 		} catch (e) {
-			sentryExceptioMessage(e,{type:'error',message:`Error resetting the Zendesk widget`});
+			sentryExceptioMessage(e, { type: 'error', message: `Error resetting the Zendesk widget` });
 			logger.error('Error resetting the Zendesk widget:', e);
 		}
 	}
@@ -702,9 +702,9 @@ export const cleanupZendeskWidget = () => {
 
 export const authenticatedRequest = async (apiCall, params = null) => {
 	const mereosToken = getAuthenticationToken();
-  
+
 	if (!mereosToken) {
-		stop_prechecks(()=>null);
+		stop_prechecks(() => null);
 		return {
 			type: 'error',
 			message: 'authentication_required',
@@ -712,17 +712,17 @@ export const authenticatedRequest = async (apiCall, params = null) => {
 			details: 'Valid authentication token required for this operation'
 		};
 	}
-  
+
 	const config = {
 		headers: {
 			token: mereosToken,
 		}
 	};
-  
+
 	if (params) {
 		config.params = params;
 	}
-  
+
 	return apiCall(config);
 };
 
@@ -732,13 +732,13 @@ export const getAuthenticationToken = () => {
 	if (tokenData) {
 		try {
 			const { token, expiresAt } = JSON.parse(tokenData);
-      
+
 			if (Date.now() > expiresAt) {
 				localStorage.removeItem('mereosToken');
 				notifyTokenExpired();
 				return null;
 			}
-      
+
 			return token;
 		} catch (error) {
 			localStorage.removeItem('mereosToken');
@@ -798,21 +798,21 @@ export const acceptableText = (detectedText, acceptedValue = 80) => {
 export const dataURLtoFile = (dataurl, filename) => {
 	let arr = dataurl?.split(','),
 		mime = arr[0].match(/:(.*?);/)[1],
-		bstr = atob(arr[arr.length - 1]), 
-		n = bstr.length, 
+		bstr = atob(arr[arr.length - 1]),
+		n = bstr.length,
 		u8arr = new Uint8Array(n);
 	while (n--) {
 		u8arr[n] = bstr.charCodeAt(n);
 	}
-	return new File([u8arr], filename, {type: mime});
+	return new File([u8arr], filename, { type: mime });
 };
 
 export const shareScreenFromContent = () => {
 	return new Promise((resolve, reject) => {
 		const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
 		const constraints = isFirefox
-			? { video: { mediaSource: 'screen' } } 
-			: { video: { displaySurface: 'monitor' } }; 
+			? { video: { mediaSource: 'screen' } }
+			: { video: { displaySurface: 'monitor' } };
 
 		navigator.mediaDevices.getDisplayMedia(constraints)
 			.then(stream => {
@@ -820,12 +820,12 @@ export const shareScreenFromContent = () => {
 
 				track.addEventListener('ended', () => {
 					window.mereos.isScreenShare = false;
-					registerEvent({notify: false, eventName: 'screen_shared_stopped', eventType: 'error'});
-					if(window.mereos.startRecordingCallBack){
-						window.mereos.startRecordingCallBack({ 
-							type:'error',
+					registerEvent({ notify: false, eventName: 'screen_shared_stopped', eventType: 'error' });
+					if (window.mereos.startRecordingCallBack) {
+						window.mereos.startRecordingCallBack({
+							type: 'error',
 							message: 'screen_share_stopped',
-							code:40012
+							code: 40012
 						});
 					}
 					openModal();
@@ -882,7 +882,7 @@ export const updatePersistData = (key, updates) => {
 
 	if (storedItemJSON) {
 		let storedItem = JSON.parse(storedItemJSON);
-		
+
 		// Merge updates into storedItem using spread operator
 		const updatedItem = {
 			...storedItem,
@@ -897,37 +897,37 @@ export const updatePersistData = (key, updates) => {
 
 export const addSectionSessionRecord = async (session) => {
 	try {
-		const { 
-			aiEvents, 
-			browserEvents 
+		const {
+			aiEvents,
+			browserEvents
 		} = session;
 		const secureFeatures = getSecureFeatures();
-		
+
 		let recordings = { data: [] };
 		let hasRecordings = false;
-		
+
 		const allRecordings = [
 			...session?.user_video_name || [],
-			...session?.user_audio_name || [], 
+			...session?.user_audio_name || [],
 			...session?.screen_sharing_video_name || [],
 			...session?.mobileRecordings || [],
 			...session?.mobileAudios || []
 		];
-		
+
 		hasRecordings = allRecordings.length > 0;
-		
+
 		if (hasRecordings) {
 			try {
-				recordings = await getRecordingSid({'source_id': allRecordings});
-				
+				recordings = await getRecordingSid({ 'source_id': allRecordings });
+
 				if (!recordings || !recordings.data) {
 					throw new Error('Invalid response from recordings API');
 				}
 			} catch (recordingError) {
-				sentryExceptioMessage(recordingError,{type:'error',message:`Failed to fetch recording SIDs`});
+				sentryExceptioMessage(recordingError, { type: 'error', message: `Failed to fetch recording SIDs` });
 				logger.error('Failed to fetch recording SIDs:', recordingError);
 				recordings = { data: [] };
-				
+
 				if (window.mereos?.globalCallback) {
 					window.mereos.globalCallback({
 						type: 'warning',
@@ -937,22 +937,22 @@ export const addSectionSessionRecord = async (session) => {
 				}
 			}
 		}
-		
+
 		const filterRecordings = (sourceArray) => {
 			if (!sourceArray || !sourceArray.length || !recordings.data || !recordings.data.length) {
 				return [];
 			}
 			return recordings.data
-				.filter(recording => 
+				.filter(recording =>
 					sourceArray.find(subrecording => subrecording === recording.source_sid)
 				)
 				.map(recording => recording.media_external_location);
 		};
-		
+
 		let sectionSessionDetails = {
 			start_time: session?.quizStartTime,
 			submission_time: session?.submissionTime,
-			duration_taken: session?.quizStartTime ? getTimeInSeconds({isUTC: true}) - session.quizStartTime : 0,
+			duration_taken: session?.quizStartTime ? getTimeInSeconds({ isUTC: true }) - session.quizStartTime : 0,
 			identity_card: session?.identityCard,
 			room_scan_video: session?.room_scan_video,
 			identity_photo: session?.candidatePhoto,
@@ -972,58 +972,58 @@ export const addSectionSessionRecord = async (session) => {
 				ram_info: session?.RAMSpeed
 			},
 			status: session?.sessionStatus,
-			video_codec: recordings.data?.filter(recording => 
+			video_codec: recordings.data?.filter(recording =>
 				session?.user_video_name?.find(subrecording => subrecording === recording.source_sid)
 			)?.map(recording => recording.codec)[0] || null,
-			video_extension: recordings.data?.filter(recording => 
+			video_extension: recordings.data?.filter(recording =>
 				session?.user_video_name?.find(subrecording => subrecording === recording.source_sid)
 			)?.map(recording => recording.container_format)[0] || null,
 			incident_level: findIncidentLevel(
 				aiEvents,
-				browserEvents, 	
+				browserEvents,
 				secureFeatures
 			),
 			mobile_audio_name: filterRecordings(session?.mobileAudios),
 			mobile_video_name: filterRecordings(session?.mobileRecordings),
 			conversation_id: localStorage.getItem('conversationId') || '',
 			candidate_assessment: session?.candidate_assessment,
-			recording_fetch_status: hasRecordings ? 
-				(recordings.data.length > 0 ? 'success' : 'failed') : 
+			recording_fetch_status: hasRecordings ?
+				(recordings.data.length > 0 ? 'success' : 'failed') :
 				'not_required'
 		};
 
 		if (session?.id) {
 			sectionSessionDetails['id'] = session?.id;
 		}
-		
-		const resp = session?.id ? 
-			await editSectionSession(sectionSessionDetails) : 
+
+		const resp = session?.id ?
+			await editSectionSession(sectionSessionDetails) :
 			await addSectionSession(sectionSessionDetails);
-		
+
 		return resp;
-		
-	} catch(err) {
-		sentryExceptioMessage(err,{type:'error',message:`Error in addSectionSessionRecord`});
+
+	} catch (err) {
+		sentryExceptioMessage(err, { type: 'error', message: `Error in addSectionSessionRecord` });
 		logger.error('Error in addSectionSessionRecord:', err);
-		
+
 		if (err.response?.status === 403) {
 			if (window.mereos?.globalCallback) {
 				window.mereos.globalCallback({
-					type: 'error', 
+					type: 'error',
 					message: 'error_saving_session_info',
-					code: 40018 
+					code: 40018
 				});
 			}
 		}
-		
+
 		if (window.mereos?.startRecordingCallBack) {
 			window.mereos.startRecordingCallBack({
-				type: 'error', 
-				message: 'error_saving_session_info', 
-				code: 40018 
+				type: 'error',
+				message: 'error_saving_session_info',
+				code: 40018
 			});
 		}
-		
+
 		throw err;
 	}
 };
@@ -1039,7 +1039,7 @@ export const getDateTime = (_dateBreaker_ = '/', _timeBreaker_ = ':', _different
 	return `${year}${_dateBreaker_}${date}${_dateBreaker_}${month}${_differentiator_}${hours}${_timeBreaker_}${minutes}${_timeBreaker_}${seconds}`;
 };
 
-export const registerAIEvent = async ({ eventName, startTime, endTime,eventValue }) => {
+export const registerAIEvent = async ({ eventName, startTime, endTime, eventValue }) => {
 	try {
 		const session = convertDataIntoParse('session');
 		if (!session || !session.aiEvents) return;
@@ -1079,13 +1079,13 @@ export const registerAIEvent = async ({ eventName, startTime, endTime,eventValue
 			updatePersistData('session', { incident_level: incidentLevel });
 		}
 	} catch (e) {
-		sentryExceptioMessage(e,{type:'error',message:`Error in registerAIEvent`});
+		sentryExceptioMessage(e, { type: 'error', message: `Error in registerAIEvent` });
 		logger.error('Error in registerAIEvent', e);
 	}
 };
 
 export const retryFailedAIEvents = async () => {
-	if (window.mereos.isRetryingAIEvent) return; 
+	if (window.mereos.isRetryingAIEvent) return;
 	window.mereos.isRetryingAIEvent = true;
 
 	const failedAIEvents = JSON.parse(localStorage.getItem('failedAIEvents') || '[]');
@@ -1109,7 +1109,7 @@ window.addEventListener('online', retryFailedAIEvents);
 
 export const lockBrowserFromContent = async (entities) => {
 	let result = {};
-	
+
 	for (const entity of entities) {
 		try {
 			switch (entity.key) {
@@ -1136,7 +1136,7 @@ export const lockBrowserFromContent = async (entities) => {
 					}
 					break;
 				}
-				
+
 				case 'disable_keyboard_shortcuts': {
 					const disableShortcuts = await preventShortCuts();
 					if (disableShortcuts) {
@@ -1184,7 +1184,7 @@ export const lockBrowserFromContent = async (entities) => {
 				// 	}
 				// 	break;
 				// }
-				
+
 				default:
 					// Do nothing for unknown keys
 					break;
@@ -1235,16 +1235,16 @@ export const disableTextHighlighting = () => {
 
 		if (
 			element.isContentEditable ||
-      element.tagName === 'INPUT' ||
-      element.tagName === 'TEXTAREA'
+			element.tagName === 'INPUT' ||
+			element.tagName === 'TEXTAREA'
 		) {
 			return true;
 		}
 
 		if (
 			element.closest &&
-      (element.closest('[contenteditable="true"]') ||
-        element.closest('.lrn_texteditor_editable'))
+			(element.closest('[contenteditable="true"]') ||
+				element.closest('.lrn_texteditor_editable'))
 		) {
 			return true;
 		}
@@ -1375,12 +1375,12 @@ export const disableCopyPasteCut = () => {
 		const keydownHandler = (e) => {
 			if (
 				(e.ctrlKey || e.metaKey) &&
-        ['c', 'v', 'x'].includes(e.key.toLowerCase())
+				['c', 'v', 'x'].includes(e.key.toLowerCase())
 			) {
 				e.preventDefault();
 
 				const eventName =
-          e.key === 'v' ? 'candidate_paste_the_content' : e.key === 'c' ? 'candidate_copy_the_content' : 'candidate_cut_the_content';
+					e.key === 'v' ? 'candidate_paste_the_content' : e.key === 'c' ? 'candidate_copy_the_content' : 'candidate_cut_the_content';
 
 				registerEvent({ notify: false, eventName, eventType: 'error' });
 
@@ -1473,7 +1473,7 @@ export const detectUnfocusOfTab = () => {
 						eventName: 'moved_away_from_page',
 						sentryError: false,
 					});
-					showToast('error','moved_away_from_page');
+					showToast('error', 'moved_away_from_page');
 				}
 			};
 
@@ -1486,7 +1486,7 @@ export const detectUnfocusOfTab = () => {
 					eventType: 'info',
 					notify: false,
 					eventName: 'moved_back_to_page',
-					duration: durationSec, 
+					duration: durationSec,
 					sentryError: false,
 				});
 				checkForceClosureViolation();
@@ -1551,7 +1551,7 @@ export const preventShortCuts = (allowedFunctionKeys = []) => {
 			183,  // Start Application 2
 			145,  // Scroll Lock
 			// Function keys (F1-F12)
-			...Array.from({length: 12}, (_, i) => 112 + i)
+			...Array.from({ length: 12 }, (_, i) => 112 + i)
 		]);
 
 		const isAlphabetKey = (key) => /^[a-zA-Z]$/.test(key);
@@ -1559,7 +1559,7 @@ export const preventShortCuts = (allowedFunctionKeys = []) => {
 		const isNumericKey = (keyCode) => keyCode >= 48 && keyCode <= 57;
 
 		const handleKeyDown = (event) => {
-			const {key, keyCode, ctrlKey, metaKey, shiftKey, altKey} = event;
+			const { key, keyCode, ctrlKey, metaKey, shiftKey, altKey } = event;
 
 			if (ctrlKey || metaKey) {
 				if (key.toLowerCase() === 'n' || key.toLowerCase() === 't') {
@@ -1569,8 +1569,8 @@ export const preventShortCuts = (allowedFunctionKeys = []) => {
 					return;
 				}
 
-				if (isAlphabetKey(key) || 
-            ['p', 's', 'o', 'u', 'i', 'w', 'f', 'tab'].includes(key.toLowerCase())) {
+				if (isAlphabetKey(key) ||
+					['p', 's', 'o', 'u', 'i', 'w', 'f', 'tab'].includes(key.toLowerCase())) {
 					event.preventDefault();
 					event.stopPropagation();
 					event.stopImmediatePropagation();
@@ -1585,8 +1585,8 @@ export const preventShortCuts = (allowedFunctionKeys = []) => {
 				return;
 			}
 
-			if (altKey && (isAlphabetKey(key) || isNumericKey(keyCode) || 
-          ['tab', 'f4'].includes(key.toLowerCase()))) {
+			if (altKey && (isAlphabetKey(key) || isNumericKey(keyCode) ||
+				['tab', 'f4'].includes(key.toLowerCase()))) {
 				event.preventDefault();
 				event.stopPropagation();
 				event.stopImmediatePropagation();
@@ -1597,15 +1597,15 @@ export const preventShortCuts = (allowedFunctionKeys = []) => {
 				if (isFunctionKey(keyCode) && allowedFunctionKeys.includes(keyCode)) {
 					return;
 				}
-        
+
 				event.preventDefault();
 				event.stopPropagation();
 				event.stopImmediatePropagation();
 			}
 		};
 
-		document.addEventListener('keydown', handleKeyDown, {capture: true, passive: false});
-		window.addEventListener('keydown', handleKeyDown, {capture: true, passive: false});
+		document.addEventListener('keydown', handleKeyDown, { capture: true, passive: false });
+		window.addEventListener('keydown', handleKeyDown, { capture: true, passive: false });
 
 		resolve(true);
 	});
@@ -1708,7 +1708,7 @@ export const detectBackButtonCallback = () => {
 	if (window.mereos.startRecordingCallBack) {
 		window.mereos.startRecordingCallBack({
 			type: 'error',
-			message: 'candidate_clicked_on_browser_back_button' ,
+			message: 'candidate_clicked_on_browser_back_button',
 			code: 40005
 		});
 		window.mereos.recordingStart = false;
@@ -1754,7 +1754,7 @@ export const unlockBrowserFromContent = () => {
 		document.body.removeChild(whiteBackgroundElement);
 	}
 
-	window.alert = function(){};
+	window.alert = function () { };
 };
 
 export const getPreviousRoute = (currentRoute, navHistory, hasFeature) => {
@@ -1793,39 +1793,39 @@ export const handlePreChecksRedirection = () => {
 	const navHistory = localStorage.getItem('navHistory');
 	const hasFeature = (featureName) => secureFeatures.some(feature => feature.key === featureName);
 
-	if(sessionSetting === 'session_resume'){
+	if (sessionSetting === 'session_resume') {
 		if (!preChecksStep?.examPreparation && secureFeatures?.filter(entity => examPreparationSteps.includes(entity.key))?.length) {
 			return 'ExamPreparation';
-		}if (!preChecksStep?.identityConfirmation && hasFeature('verify_id')) {
+		} if (!preChecksStep?.identityConfirmation && hasFeature('verify_id')) {
 			return 'IdentityCardRequirement';
-		} else if(!preChecksStep?.diagnosticStep && secureFeatures?.filter(entity => systemDiagnosticSteps.includes(entity.key))?.length){
+		} else if (!preChecksStep?.diagnosticStep && secureFeatures?.filter(entity => systemDiagnosticSteps.includes(entity.key))?.length) {
 			return 'runSystemDiagnostics';
-		} else if(!preChecksStep?.requirementStep && secureFeatures?.filter(entity => SYSTEM_REQUIREMENT_STEP.includes(entity.key))?.length){
+		} else if (!preChecksStep?.requirementStep && secureFeatures?.filter(entity => SYSTEM_REQUIREMENT_STEP.includes(entity.key))?.length) {
 			return 'SystemRequirements';
-		} else if(!preChecksStep?.browserSecurity && secureFeatures?.filter(entity => BROWSER_SECURTIY_STEP.includes(entity.key))?.length){
+		} else if (!preChecksStep?.browserSecurity && secureFeatures?.filter(entity => BROWSER_SECURTIY_STEP.includes(entity.key))?.length) {
 			return 'BrowserSecurity';
-		}	else if(!preChecksStep?.preValidation && hasFeature('verify_multiple_devices')){
+		} else if (!preChecksStep?.preValidation && hasFeature('verify_multiple_devices')) {
 			return 'Prevalidationinstruction';
 		}
-		else if(!preChecksStep?.userPhoto && hasFeature('verify_candidate')){
+		else if (!preChecksStep?.userPhoto && hasFeature('verify_candidate')) {
 			return 'IdentityVerificationScreenOne';
-		}else if(!preChecksStep?.identityCardPhoto && hasFeature('verify_id')){
+		} else if (!preChecksStep?.identityCardPhoto && hasFeature('verify_id')) {
 			return 'IdentityVerificationScreenTwo';
-		}else if(!preChecksStep?.audioDetection && hasFeature('record_audio')){
+		} else if (!preChecksStep?.audioDetection && hasFeature('record_audio')) {
 			return 'IdentityVerificationScreenThree';
-		}else if(!preChecksStep?.roomScanningVideo && hasFeature('record_room')){
+		} else if (!preChecksStep?.roomScanningVideo && hasFeature('record_room')) {
 			return 'IdentityVerificationScreenFour';
-		}else if(!preChecksStep?.mobileConnection && hasFeature('mobile_proctoring') || !window.mereos?.mobileStream){
+		} else if (!preChecksStep?.mobileConnection && hasFeature('mobile_proctoring') || !window.mereos?.mobileStream) {
 			return 'MobileProctoring';
-		}else if(!preChecksStep?.screenSharing || hasFeature('record_screen')){
+		} else if (!preChecksStep?.screenSharing || hasFeature('record_screen')) {
 			return 'IdentityVerificationScreenFive';
-		} else{
+		} else {
 			closeModal();
 		}
-	}else{
+	} else {
 		if ((window.mereos.precheckCompleted && hasFeature('record_screen')) || navHistory?.includes('IdentityVerificationScreenFive')) {
 			return 'IdentityVerificationScreenFive';
-		}else{
+		} else {
 			localStorage.setItem('preChecksSteps', JSON.stringify(preChecksSteps));
 			return 'ExamPreparation';
 		}
@@ -1833,7 +1833,7 @@ export const handlePreChecksRedirection = () => {
 };
 
 export const normalizeLanguage = (input) => {
-	if (!input) return 'en'; 
+	if (!input) return 'en';
 	input = input.toLowerCase();
 	if (input.includes('-')) {
 		return input.split('-')[0];
@@ -1842,11 +1842,11 @@ export const normalizeLanguage = (input) => {
 		french: 'fr',
 		english: 'en',
 		spanish: 'es',
-		german:'de',
-		italian:'it',
-		dutch:'nl',
-		portugese:'pt',
-		welsh:'cy'
+		german: 'de',
+		italian: 'it',
+		dutch: 'nl',
+		portugese: 'pt',
+		welsh: 'cy'
 	};
 	return languageMap[input] || input;
 };
@@ -1868,10 +1868,10 @@ export const initializeI18next = () => {
 		resources: {
 			cy: {
 				translation: require('../assets/locales/cy/translation.json')
-			}, 
+			},
 			en: {
 				translation: require('../assets/locales/en/translation.json')
-			}, 
+			},
 			fr: {
 				translation: require('../assets/locales/fr/translation.json')
 			},
@@ -1889,7 +1889,7 @@ export const initializeI18next = () => {
 			},
 			de: {
 				translation: require('../assets/locales/de/translation.json')
-			},	 
+			},
 		}
 	}, (err) => {
 		if (err) return logger.error('Error in language', err);
@@ -1904,17 +1904,17 @@ export const showToast = (type, message) => {
 	const secureFeatures = getSecureFeature?.entities || [];
 	const hasNotifyFeature = secureFeatures?.some(entity => entity.key === 'notify');
 
-	if(hasNotifyFeature){
+	if (hasNotifyFeature) {
 		const notyf = new Notyf();
 		loadNotyfCss();
 		const translatedMessage = i18next.t(message);
 		const options = {
 			message: i18next.t(translatedMessage),
-			duration: 3000, 
+			duration: 3000,
 			position: { x: 'right', y: 'top' },
-			ripple: true 
+			ripple: true
 		};
-	
+
 		switch (type) {
 			case 'error':
 				notyf.error(options);
@@ -1945,10 +1945,10 @@ export const getRAMInfo = async () => {
 		capacity: 'Unknown',
 		availableCapacity: 'Unknown',
 	};
-	
+
 	if ('deviceMemory' in navigator) {
 		memoryInfo.capacity = (navigator.deviceMemory * 1024 ** 3).toFixed(0);
-	} 
+	}
 	else if ('hardwareConcurrency' in navigator) {
 		memoryInfo.capacity = (navigator.hardwareConcurrency * 2 * 1024 ** 3).toFixed(0);
 	} else {
@@ -1996,61 +1996,298 @@ export const getCPUInfo = () => {
 	});
 };
 
-export const getNetworkDownloadSpeed = () => {
-	return new Promise((resolve, _reject) => {
-		const imageAddr = 'http://d3ia9qn5swl78e.cloudfront.net/images/detection-side-img.svg'; 
-		var downloadSize = 1263621; // bytes
-		
-		let startTime, endTime;
-		const download = new Image();
-		download.onload = function () {
-			endTime = (new Date()).getTime();
-			const duration = (endTime - startTime) / 1000;
-			const bitsLoaded = downloadSize * 8;
-			const speedBps = (bitsLoaded / duration).toFixed(2);
-			const speedKbps = (speedBps / 1024).toFixed(2);
-			const speedMbps = (speedKbps / 1024).toFixed(2);
-			const speed = {
-				speedBps, 
-				speedKbps,
-				speedMbps
-			};
-			resolve(speed);
-		};
-		
-		startTime = (new Date()).getTime();
-		var cacheBuster = '?nnn=' + startTime;
-		download.src = imageAddr + cacheBuster;
+const CLOUDFLARE_DOWN = 'https://speed.cloudflare.com/__down';
+
+const formatNetworkSpeed = (bitsPerSecond, extra = {}) => ({
+	speedBps: bitsPerSecond.toFixed(2),
+	speedKbps: (bitsPerSecond / 1000).toFixed(2),
+	speedMbps: (bitsPerSecond / 1_000_000).toFixed(2),
+	...extra,
+});
+
+const getSpeedPercentile = (values, percentile = 0.9) => {
+	if (!values.length) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const index = Math.min(sorted.length - 1, Math.ceil(sorted.length * percentile) - 1);
+	return sorted[index];
+};
+
+// Median for small batches; 90th percentile for larger sets (filters timing jitter).
+const getStableSpeed = (samples) => {
+	if (!samples.length) return 0;
+	if (samples.length <= 3) return getSpeedPercentile(samples, 0.5);
+	return getSpeedPercentile(samples, 0.9);
+};
+
+const DOWNLOAD_INITIAL_SAMPLES = 3;
+const DOWNLOAD_REFINED_SAMPLES = 3;
+const UPLOAD_PAYLOAD_SIZES_KB = [512, 2048, 8192, 10240];
+const MIN_UPLOAD_DURATION_SEC = 0.8;
+
+const warmUpDownload = async () => {
+	await fetch(`${CLOUDFLARE_DOWN}?bytes=100000&cache_bust=${Date.now()}`, { cache: 'no-store' });
+};
+
+const measureDownloadOnce = async (bytes) => {
+	const response = await fetch(`${CLOUDFLARE_DOWN}?bytes=${bytes}&cache_bust=${Date.now()}`, { cache: 'no-store' });
+	if (!response.ok) {
+		throw new Error(`Download test failed (${response.status})`);
+	}
+
+	const reader = response.body?.getReader();
+	let bytesReceived = 0;
+	let startTime = null;
+
+	if (reader) {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!startTime) startTime = performance.now();
+			bytesReceived += value.byteLength;
+		}
+	} else {
+		startTime = performance.now();
+		const blob = await response.blob();
+		bytesReceived = blob.size;
+	}
+
+	const duration = startTime ? (performance.now() - startTime) / 1000 : 0;
+	if (!duration || duration <= 0 || !bytesReceived) {
+		throw new Error('Invalid download duration');
+	}
+
+	return (bytesReceived * 8) / duration;
+};
+
+const sampleDownloadSpeed = async (bytes, count) => {
+	const samples = [];
+
+	for (let i = 0; i < count; i++) {
+		try {
+			samples.push(await measureDownloadOnce(bytes));
+		} catch (error) {
+			logger.warn('[mereos] Download sample failed', error);
+		}
+	}
+
+	return getStableSpeed(samples);
+};
+
+/*
+	Purpose:
+	- Estimate upload speed with progressively larger payloads.
+	- Uses 4 strategic sizes (512KB → 10MB) and stops once upload duration >= 0.8s.
+	- Falls back to the longest-duration attempt for very fast connections.
+*/
+export const getNetworkUploadSpeed = () => {
+	return new Promise(async (resolve) => {
+		try {
+			const url = `${BASE_URL}/general/candidate_info/`;
+			let best = null;
+
+			for (const size of UPLOAD_PAYLOAD_SIZES_KB) {
+				const data = { name: 'a'.repeat(size * 1024) };
+				const result = await sendUploadRequest(url, data);
+
+				if (!result) continue;
+
+				const { duration, bitsLoaded } = result;
+				if (!duration || duration <= 0 || !bitsLoaded) continue;
+
+				const speedBps = (bitsLoaded / duration).toFixed(2);
+				const speedKbps = (speedBps / 1024).toFixed(2);
+				const speedMbps = (speedKbps / 1024).toFixed(2);
+				const candidate = { speedBps, speedKbps, speedMbps, duration };
+
+				if (!best || candidate.duration > best.duration) best = candidate;
+
+				if (duration >= MIN_UPLOAD_DURATION_SEC) {
+					return resolve({ speedBps, speedKbps, speedMbps });
+				}
+			}
+
+			if (best) {
+				const { speedBps, speedKbps, speedMbps } = best;
+				return resolve({ speedBps, speedKbps, speedMbps });
+			}
+
+			resolve(false);
+		} catch (error) {
+			console.log('Upload speed check failed:', error);
+			resolve(false);
+		}
 	});
 };
 
-export const getNetworkUploadSpeed = async () => {
+/*
+	Purpose:
+	- POST a JSON body to the server.
+	- Measure ONLY the upload portion (bytes leaving the client), not server processing time.
+
+	Timing approach:
+	- We use upload lifecycle events:
+	  - http.upload.onloadstart -> marks when the upload begins
+	  - http.upload.onloadend   -> marks when the upload finishes sending bytes
+	- This is generally more reliable than relying purely on onprogress for timing.
+
+	Byte counting approach:
+	- Prefer actual bytes reported by upload progress (e.loaded).
+	- If progress doesn't provide bytes (can happen in some environments),
+	  fall back to estimating bytes from the UTF-8 size of the JSON body.
+
+	Return values:
+	- resolve({ duration, bitsLoaded }) when the measurement is valid
+	- resolve(null) when the attempt should be ignored (failed request, non-200, unreliable timing, etc.)
+*/
+function sendUploadRequest(url, data) {
+	return new Promise(async (resolve) => {
+		// Using XHR because it gives us upload progress + upload lifecycle events.
+		const http = new XMLHttpRequest();
+		const token = await Promise.resolve(getAuthenticationToken());
+
+		// Async POST request.
+		http.open('POST', url, true);
+
+		// JSON body content type.
+		http.setRequestHeader('Content-Type', 'application/json');
+		http.setRequestHeader('token', token);
+
+		// Build request body once so we can:
+		// 1) send it
+		// 2) estimate payload size if progress events don't give us bytes
+		const body = JSON.stringify(data);
+
+		// Upload timestamps in milliseconds (performance.now()).
+		let uploadStart = null;
+		let uploadEnd = null;
+
+		// Bytes reported by upload progress.
+		// We'll store the latest value we see.
+		let loadedBytesFromProgress = 0;
+
+		http.upload.onloadstart = () => {
+			// Marks when the browser actually starts sending bytes to the network.
+			uploadStart = performance.now();
+		};
+
+		http.upload.onprogress = (e) => {
+			// Progress event gives us how many bytes have been uploaded so far.
+			// Some browsers / environments may not fire this consistently.
+			if (e?.loaded) loadedBytesFromProgress = e.loaded;
+		};
+
+		http.upload.onloadend = () => {
+			// Marks when the upload finishes sending bytes (before/while response is coming back).
+			uploadEnd = performance.now();
+		};
+
+		http.onreadystatechange = () => {
+			// readyState 4 means the full request/response cycle completed.
+			if (http.readyState !== 4) return;
+
+			// Only treat HTTP 200 as success (as per current logic).
+			// Anything else is considered a failed attempt and we let caller try the next payload size.
+			if (http.status !== 200) return resolve(null);
+
+			// If uploadEnd didn't get recorded (rare), fallback to now.
+			// If uploadStart never recorded, start=end -> duration becomes 0 and we reject below.
+			const end = uploadEnd ?? performance.now();
+			const start = uploadStart ?? end;
+
+			// Upload duration in seconds.
+			// NOTE: This measures upload time only, not total request time.
+			const duration = (end - start) / 1000;
+
+			// If uploadStart never fired or timing got collapsed, duration will be ~0.
+			// That reading is too unreliable, so ignore the attempt.
+			if (!duration || duration <= 0) return resolve(null);
+
+			// Byte calculation:
+			// - If progress reported bytes, use that (best case).
+			// - Otherwise, estimate bytes from the UTF-8 byte length of the JSON string.
+			const bytesLoaded =
+				loadedBytesFromProgress > 0 ? loadedBytesFromProgress : getUtf8ByteLength(body);
+
+			// Convert bytes to bits.
+			const bitsLoaded = bytesLoaded * 8;
+
+			// If bytes are still 0 for some reason, treat as invalid attempt.
+			if (!bitsLoaded) return resolve(null);
+
+			// Return the measurement to the caller.
+			resolve({ duration, bitsLoaded });
+		};
+
+		// Network-level failure:
+		// - blocked by proxy/VPN/firewall
+		// - offline / DNS issues
+		// - CORS/network error scenarios that surface as an XHR error
+		http.onerror = () => resolve(null);
+
+		// If timeout is configured elsewhere in the app/environment, treat it as a failed attempt.
+		http.ontimeout = () => resolve(null);
+
+		// Send the request body.
+		http.send(body);
+	});
+}
+
+function getUtf8ByteLength(str) {
 	try {
-		const myData = { 'test': 'a'.repeat(1024 * 1024) };
-		const startTime = new Date().getTime();
-
-		const response = await testUploadSpeed({ 'test': 'a'.repeat(1024 * 1024) });
-
-		if(response){
-			const endTime = new Date().getTime();
-			const duration = (endTime - startTime) / 1000;
-			const bitsLoaded = myData.test.length * 8;
-			const speedBps = (bitsLoaded / duration).toFixed(2);
-			const speedKbps = (speedBps / 1024).toFixed(2);
-			const speedMbps = (speedKbps / 1024).toFixed(2);
-
-			return { 	
-				speedBps,
-				speedKbps,
-				speedMbps 
-			};
-		}
-        
-	} catch (err) {
-		sentryExceptioMessage(err);
-		console.error(err);
-		return false;
+		return new TextEncoder().encode(str).length;
+	} catch (e) {
+		return str.length;
 	}
+}
+
+export const getNetworkDownloadSpeed = () => {
+	console.log('[mereos] Starting download speed test...');
+	logger.info('[mereos] Starting download speed test');
+
+	return (async () => {
+		try {
+			await warmUpDownload();
+
+			let bytes = 1_000_000;
+			let count = DOWNLOAD_INITIAL_SAMPLES;
+			let message = `Measured using ${count}×1MB samples after warm-up.`;
+
+			let bitsPerSecond = await sampleDownloadSpeed(bytes, count);
+			const initialMbps = bitsPerSecond / 1_000_000;
+
+			if (initialMbps > 50) {
+				bytes = 25_000_000;
+				count = DOWNLOAD_REFINED_SAMPLES;
+				message = `Measured using ${count}×25MB samples after warm-up.`;
+				bitsPerSecond = await sampleDownloadSpeed(bytes, count);
+			} else if (initialMbps > 10) {
+				bytes = 10_000_000;
+				count = DOWNLOAD_REFINED_SAMPLES;
+				message = `Measured using ${count}×10MB samples after warm-up.`;
+				bitsPerSecond = await sampleDownloadSpeed(bytes, count);
+			}
+
+			if (!bitsPerSecond) {
+				throw new Error('No valid download samples');
+			}
+
+			const result = formatNetworkSpeed(bitsPerSecond, {
+				isRefined: initialMbps > 10,
+				message,
+				sampleBytes: bytes,
+				sampleCount: count,
+			});
+
+			console.log('[mereos] Download speed:', result);
+			logger.info('[mereos] Download speed', result);
+			return result;
+		} catch (err) {
+			console.error('[mereos] Download speed test failed:', err);
+			logger.error('[mereos] Download speed test failed', err);
+			sentryExceptioMessage(err, { type: 'error', message: 'Error measuring download speed' });
+			throw new Error('Error measuring download speed: ' + err.message);
+		}
+	})();
 };
 
 export const checkPermissionStatus = async () => {
@@ -2075,16 +2312,16 @@ export const handleBackendError = (t, error) => {
 
 	if (!error) {
 		message = t('something_went_wrong_please_try_again_later');
-	} 
+	}
 	else if (typeof error === 'string') {
 		const translated = t(error);
 		message = translated !== error ? translated : error;
-	} 
+	}
 	else if (typeof error === 'object') {
 		if (error && typeof error === 'string') {
 			const translated = t(error);
 			message = translated !== error ? translated : error;
-		} 
+		}
 		else if (typeof error === 'object') {
 			const firstKey = Object.keys(error)[0];
 			const firstMsgArray = error[firstKey];
@@ -2170,13 +2407,13 @@ export const enumerateByKind = async () => {
 export const isDevicePresent = async (kind, deviceId) => {
 	const byKind = await enumerateByKind();
 	const list = kind === 'audio' ? byKind.audioinput : byKind.videoinput;
-	if (!deviceId) return list.length > 0; 
+	if (!deviceId) return list.length > 0;
 	return list.some(d => d.deviceId === deviceId);
 };
 
 export const probeExactDevice = async (kind, deviceId) => {
 	const constraints =
-    kind === 'video' ? { video: deviceId ? { deviceId: { exact: deviceId } } : true } : { audio: deviceId ? { deviceId: { exact: deviceId } } : true };
+		kind === 'video' ? { video: deviceId ? { deviceId: { exact: deviceId } } : true } : { audio: deviceId ? { deviceId: { exact: deviceId } } : true };
 
 	const stream = await navigator.mediaDevices.getUserMedia(constraints);
 	const track = stream.getTracks()[0];
@@ -2201,7 +2438,7 @@ const routeToPrecheckKey = {
 	ExamPreparation: 'examPreparation',
 	runSystemDiagnostics: 'diagnosticStep',
 	SystemRequirements: 'requirementStep',
-	BrowserSecurity:'browserSecurity',
+	BrowserSecurity: 'browserSecurity',
 	Prevalidationinstruction: 'preValidation',
 
 	IdentityVerificationScreenOne: 'userPhoto',
@@ -2227,7 +2464,7 @@ const stepToVideoId = {
 	ExamPreparation: 'full-demo',
 	runSystemDiagnostics: 'system-diagnostic',
 	SystemRequirements: 'system-requirement',
-	
+
 	IdentityVerificationScreenOne: 'candidate-photo',
 	IdentityVerificationScreenTwo: 'identity-card',
 	IdentityVerificationScreenThree: 'detect-microphone',
@@ -2265,19 +2502,19 @@ export const detectBrowserActions = async () => {
 		localStorage.removeItem('examLeaveTime');
 	}
 
-	window.mereos.startRecordingCallBack({ 
+	window.mereos.startRecordingCallBack({
 		type: 'error',
-		message: navType === 'navigate' ? 'candidate_came_back_to_assessment_page': navType === 'back_forward'? 'candidate_move_back_or_forward_from_the_page': 'candidate_refreshed_the_assessment_page',
+		message: navType === 'navigate' ? 'candidate_came_back_to_assessment_page' : navType === 'back_forward' ? 'candidate_move_back_or_forward_from_the_page' : 'candidate_refreshed_the_assessment_page',
 		code: 40019
 	});
 
-	if(session?.quizStartTime > 1 && session?.sessionStatus === 'Attending'){
+	if (session?.quizStartTime > 1 && session?.sessionStatus === 'Attending') {
 		registerEvent({
 			eventType: 'error',
 			notify: false,
-			eventName:navType === 'navigate' ? 'candidate_came_back_to_assessment_page': navType === 'back_forward'? 'candidate_move_back_or_forward_from_the_page': 'candidate_refreshed_the_assessment_page',
-			duration:timeDiff,
-			eventValue:navType
+			eventName: navType === 'navigate' ? 'candidate_came_back_to_assessment_page' : navType === 'back_forward' ? 'candidate_move_back_or_forward_from_the_page' : 'candidate_refreshed_the_assessment_page',
+			duration: timeDiff,
+			eventValue: navType
 		});
 	}
 

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -58,6 +58,8 @@ export const dataURIToBlob = (dataURI) => {
 
 export const forceClosure = async () => {
 	try {
+		await releaseAllMediaStreams();
+
 		const secureFeatures = getSecureFeatures();
 		const candidateInviteAssessmentSection = convertDataIntoParse('candidateAssessment');
 
@@ -118,7 +120,6 @@ export const forceClosure = async () => {
 				resetSessionData();
 			}
 		} else {
-			window.mereos.roomInstance = null;
 			window.mereos.recordingStart = false;
 			if (window.mereos.startRecordingCallBack) {
 				window.mereos.startRecordingCallBack({
@@ -136,6 +137,8 @@ export const forceClosure = async () => {
 };
 
 export const resetSessionData = () => {
+	void releaseAllMediaStreams();
+
 	if (window.mereos.aiProcessingInterval) {
 		clearInterval(window.mereos.aiProcessingInterval);
 		window.mereos.aiProcessingInterval = null;
@@ -700,6 +703,232 @@ export const cleanupZendeskWidget = () => {
 	}
 };
 
+const activeMediaTracks = new Set();
+
+const registerActiveTracks = (...sources) => {
+	for (const source of sources) {
+		if (!source) continue;
+		if (typeof source.getTracks === 'function') {
+			source.getTracks().forEach((track) => activeMediaTracks.add(track));
+		} else if (source.mediaStreamTrack) {
+			activeMediaTracks.add(source.mediaStreamTrack);
+		} else if (source.kind && typeof source.stop === 'function') {
+			activeMediaTracks.add(source);
+		}
+	}
+};
+
+const installActiveMediaTrackRegistry = () => {
+	if (typeof navigator === 'undefined' || installActiveMediaTrackRegistry.installed) return;
+	installActiveMediaTrackRegistry.installed = true;
+
+	const captureStream = (stream) => {
+		registerActiveTracks(stream);
+		return stream;
+	};
+
+	if (navigator.mediaDevices?.getUserMedia) {
+		const nativeGetUserMedia = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+		navigator.mediaDevices.getUserMedia = (constraints) =>
+			Promise.resolve(nativeGetUserMedia(constraints)).then(captureStream);
+	}
+
+	if (navigator.mediaDevices?.getDisplayMedia) {
+		const nativeGetDisplayMedia = navigator.mediaDevices.getDisplayMedia.bind(navigator.mediaDevices);
+		navigator.mediaDevices.getDisplayMedia = (constraints) =>
+			Promise.resolve(nativeGetDisplayMedia(constraints)).then(captureStream);
+	}
+
+	['getUserMedia', 'webkitGetUserMedia', 'mozGetUserMedia', 'msGetUserMedia'].forEach((methodName) => {
+		if (typeof navigator[methodName] !== 'function') return;
+		const nativeLegacy = navigator[methodName].bind(navigator);
+		navigator[methodName] = (constraints, onSuccess, onError) => {
+			nativeLegacy(
+				constraints,
+				(stream) => {
+					captureStream(stream);
+					onSuccess?.(stream);
+				},
+				onError,
+			);
+		};
+	});
+};
+
+if (typeof window !== 'undefined') {
+	installActiveMediaTrackRegistry();
+}
+
+const stopMediaStreamTrack = (track) => {
+	if (!track || track.readyState === 'ended') return;
+	try {
+		track.stop();
+		track.enabled = false;
+	} catch (error) {
+		logger.error('Failed to stop media track:', error);
+	}
+};
+
+const collectLocalTwilioTracks = (localParticipant) => {
+	if (!localParticipant) return [];
+	const tracks = new Set();
+	const addFromMap = (map) => {
+		map?.forEach?.((publication) => {
+			if (publication?.track) tracks.add(publication.track);
+		});
+	};
+	addFromMap(localParticipant.tracks);
+	addFromMap(localParticipant.videoTracks);
+	addFromMap(localParticipant.audioTracks);
+	return Array.from(tracks);
+};
+
+const unbindMediaElements = () => {
+	const mereos = window.mereos || {};
+	const roots = [document];
+	if (mereos.shadowRoot) roots.push(mereos.shadowRoot);
+	const host = document.getElementById('mereos-library');
+	if (host?.shadowRoot && !roots.includes(host.shadowRoot)) roots.push(host.shadowRoot);
+
+	roots.forEach((root) => {
+		root.querySelectorAll('video, audio').forEach((element) => {
+			try {
+				element.pause?.();
+				if (element.srcObject?.getTracks) {
+					element.srcObject.getTracks().forEach(stopMediaStreamTrack);
+				}
+				element.srcObject = null;
+				element.removeAttribute('src');
+				if (element.src) element.src = '';
+			} catch (error) {
+				logger.error('Failed to unbind media element:', error);
+			}
+		});
+	});
+};
+
+let releasingMediaStreams = null;
+
+const stopAllActiveTracks = () => {
+	Array.from(activeMediaTracks).forEach(stopMediaStreamTrack);
+	activeMediaTracks.clear();
+};
+
+export const releaseAllMediaStreams = async () => {
+	if (releasingMediaStreams) return releasingMediaStreams;
+
+	releasingMediaStreams = (async () => {
+		const mereos = window.mereos || {};
+
+		if (mereos.aiProcessingInterval) {
+			clearInterval(mereos.aiProcessingInterval);
+			mereos.aiProcessingInterval = null;
+		}
+
+		if (mereos.aiProcessingVideo) {
+			mereos.aiProcessingVideo.pause?.();
+			registerActiveTracks(mereos.aiProcessingVideo.srcObject);
+			if (mereos.aiProcessingVideo.srcObject?.getTracks) {
+				mereos.aiProcessingVideo.srcObject.getTracks().forEach(stopMediaStreamTrack);
+			}
+			mereos.aiProcessingVideo.srcObject = null;
+			mereos.aiProcessingVideo = null;
+		}
+
+		const rooms = [mereos.roomInstance, mereos.mobileRoomInstance].filter(Boolean);
+		const twilioTracks = rooms.flatMap((room) =>
+			collectLocalTwilioTracks(room.localParticipant)
+		);
+
+		registerActiveTracks(
+			mereos.globalStream,
+			mereos.newStream,
+			mereos.mobileStream,
+			mereos.audioStream,
+			mereos.screenTrackPublished?.track,
+			...twilioTracks
+		);
+
+		unbindMediaElements();
+
+		for (const room of rooms) {
+			try {
+				for (const track of collectLocalTwilioTracks(room.localParticipant)) {
+					try {
+						(track.detach?.() || []).forEach((element) => {
+							element.pause?.();
+							if (element.srcObject?.getTracks) {
+								element.srcObject.getTracks().forEach(stopMediaStreamTrack);
+							}
+							element.srcObject = null;
+							element.remove?.();
+						});
+					} catch (error) {
+						logger.error('Failed to detach Twilio track:', error);
+					}
+				}
+
+				room.participants?.forEach((participant) => participant.removeAllListeners?.());
+				room.removeAllListeners?.();
+				room.disconnect();
+			} catch (error) {
+				logger.error('Failed to disconnect Twilio room:', error);
+			}
+		}
+
+		for (const track of twilioTracks) {
+			try {
+				track.disable?.();
+				stopMediaStreamTrack(track.mediaStreamTrack);
+				track.stop?.();
+			} catch (error) {
+				logger.error('Failed to stop Twilio track:', error);
+			}
+		}
+
+		[
+			mereos.globalStream,
+			mereos.newStream,
+			mereos.mobileStream,
+			mereos.audioStream,
+		].forEach((stream) => stream?.getTracks?.().forEach(stopMediaStreamTrack));
+
+		const screenTrack = mereos.screenTrackPublished?.track;
+		if (screenTrack) {
+			try {
+				stopMediaStreamTrack(screenTrack.mediaStreamTrack);
+				screenTrack.stop?.();
+			} catch (error) {
+				logger.error('Failed to stop screen share track:', error);
+			}
+		}
+
+		try {
+			mereos.peerInstance?.destroy?.();
+		} catch (error) {
+			logger.error('Failed to destroy peer connection:', error);
+		}
+
+		unbindMediaElements();
+		stopAllActiveTracks();
+
+		mereos.roomInstance = null;
+		mereos.mobileRoomInstance = null;
+		mereos.globalStream = null;
+		mereos.newStream = null;
+		mereos.mobileStream = null;
+		mereos.audioStream = null;
+		mereos.screenTrackPublished = null;
+		mereos.peerInstance = null;
+	})();
+
+	try {
+		await releasingMediaStreams;
+	} finally {
+		releasingMediaStreams = null;
+	}
+};
+
 export const authenticatedRequest = async (apiCall, params = null) => {
 	const mereosToken = getAuthenticationToken();
 
@@ -856,7 +1085,8 @@ export const getSecureFeatures = () => {
 
 export const checkForMultipleMicrophones = async () => {
 	try {
-		await navigator.mediaDevices.getUserMedia({ audio: true });
+		const probeStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+		probeStream.getTracks().forEach(stopMediaStreamTrack);
 
 		const devices = await navigator.mediaDevices.enumerateDevices();
 

--- a/src/utils/sentry.js
+++ b/src/utils/sentry.js
@@ -1,7 +1,26 @@
-import { Replay } from '@sentry/replay';
 import * as Sentry from '@sentry/browser';
 
+const MEREOS_SENTRY_INIT_KEY = '__mereosSentryInitialized';
+
+const isSentryAlreadyInitialized = () => {
+	if (typeof Sentry.getClient === 'function' && Sentry.getClient()) {
+		return true;
+	}
+	if (typeof window !== 'undefined' && window[MEREOS_SENTRY_INIT_KEY]) {
+		return true;
+	}
+	return false;
+};
+
 const initSentry = (environment = 'production') => {
+	/*
+	 * Session Replay allows only one instance per page. Skip init when Sentry is
+	 * already set up (second mereos load, or LMS host app initialized Sentry first).
+	 */
+	if (isSentryAlreadyInitialized()) {
+		return;
+	}
+
 	Sentry.init({
 		dsn: 'https://edb36d1ddfd737dbf7b6d291a63d192a@o4507933105389568.ingest.de.sentry.io/4510827301634128',
 
@@ -10,16 +29,20 @@ const initSentry = (environment = 'production') => {
 			Sentry.browserTracingIntegration({
 				tracePropagationTargets: ['localhost', /^\//],
 			}),
-			new Replay(),
+			Sentry.replayIntegration(),
 		],
 
 		environment: environment,
 
 		profileSessionSampleRate: 0.5,
-		tracesSampleRate: 0.1,          // ✅ good for prod
-		replaysSessionSampleRate: 0.05, // ✅ good
-		replaysOnErrorSampleRate: 1.0,  // ✅ perfect
+		tracesSampleRate: 0.1,
+		replaysSessionSampleRate: 0.05,
+		replaysOnErrorSampleRate: 1.0,
 	});
+
+	if (typeof window !== 'undefined') {
+		window[MEREOS_SENTRY_INIT_KEY] = true;
+	}
 };
 
 export { initSentry };


### PR DESCRIPTION
- Added local dev workflow with `npm run dev` using a Vite-based playground and a orchestrator that generates temp assets and cleans them up on exit.
- Added templates with on-page log mirroring of console output.
- Added Vite browser-compat plugin to patch `require()` usage for browser ESM without modifying source files on disk.
- Updated dev server config for HMR: `mereos` alias, `src/` file watching, and hot module invalidation so library changes reload without restarting the server.
- Added `vite` as a dev dependency and updated `.gitignore`.
- Refactored download speed test from CloudFront image timing to Cloudflare `__down` with warm-up, stream-based measurement, multi-sample aggregation, and tiered payload sizes.
- Optimized download sampling to 3 samples per tier with median/percentile stabilization for faster runs while keeping accuracy.
- Refactored upload speed test from a single `testUploadSpeed` API call to XHR-based progressive payloads.
- Optimized upload test to 4 strategic payload sizes with 0.8s early-exit and longest-duration fallback.
- Updated `SystemRequirement` to wrap RAM/CPU/upload/download checks in try/catch with proper failure UI, Sentry logging, and download speed failure events.
- Added centralized `releaseAllMediaStreams()` utility to fully release camera, microphone, screen share, Twilio, AI processing, and peer connections across session end paths.
- Added active media track registry that patches `getUserMedia` / `getDisplayMedia` so all captured tracks are tracked and stopped on cleanup.
- Refactored `stopAllRecordings()` to use centralized cleanup instead of scattered inline Twilio/media teardown logic.
- Updated `stop_session()` and `stop_prechecks()` to call `releaseAllMediaStreams()` at session/precheck end.
- Updated `forceClosure()` and `resetSessionData()` to release media before session reset and callbacks.
- Added media cleanup to non-button termination paths: recording start failure, Twilio connect failure, device reconnection failure, participant reconnecting, and mobile violation socket events.
- Updated `startRecording()` to stop precheck `globalStream` / `audioStream` before Twilio connect.
- Updated AI webcam flow to register `aiProcessingVideo` on `window.mereos` for reliable cleanup.
- Updated `MobileProctoring` violation handler to use full media release instead of stopping only `mobileStream`.
- Fixed microphone probe in `checkForMultipleMicrophones()` to stop the test stream immediately after permission check.
- Investigated LMS reports of missing `start_session` callbacks; root cause was silent exits and async gaps in the session flow, not Sentry catch blocks.
- Refactored `start_session` in `index.js` to always invoke the LMS callback via a shared `invokeCallback` helper.
- Changed `start_session` to `await startRecording()` so errors surface to the integrator instead of escaping unhandled.
- Added early success return when `roomInstance` already exists to avoid duplicate Twilio rooms on retry.
- Updated stale `recordingStart` handling so failed or interrupted attempts can retry without blocking the next call.
- Added missing Twilio token guards and reset `recordingStart` on token and room-creation failures.
- Limited `session_resume` token reuse to the `session_resume` precheck path only; preserved `quizStartTime` across resume.
- Refactored `startRecording` in `src/StartRecording/index.js` with outer try/catch so lockdown, fullscreen, and session persistence failures invoke the LMS callback.
- Fixed Twilio connect failure path to return immediately with `room_is_not_creating` instead of continuing with an undefined room.
- Added `waitForParticipantVideoTracks` for event-based video track readiness.
- Updated error handling to reset `recordingStart`, distinguish permission vs generic failures, and avoid duplicate success callbacks after AI webcam failure.
- Re-read `twilioToken` from localStorage before connect so `session_resume` uses the stored token.
- Changed `detectBrowserActions` to fire navigation callbacks only during an active attending session on real reload/back/navigation return, not on first page load.
- Refactored Sentry init to skip duplicate initialization and removed `@sentry/replay` in favor of `Sentry.replayIntegration()` to fix “Multiple Sentry Session Replay instances” console errors.